### PR TITLE
adding signed 'Version' branch

### DIFF
--- a/documentation/api/api-v2.md
+++ b/documentation/api/api-v2.md
@@ -26,6 +26,7 @@ The current service address is `app.Encryptonize`. The Encryptonize API defines 
 * `rpc AddPermission (AddPermissionRequest) returns (ReturnCode)`
 * `rpc RemovePermission (RemovePermissionRequest) returns (ReturnCode)`
 * `rpc CreateUser (CreateUserRequest) returns (CreateUserResponse)`
+* `rpc Version (VersionRequest) returns (VersionResponse)`
 
 For detailed information, see below.
 
@@ -140,6 +141,15 @@ access list.
 | object_id | string | The object                            |
 | target    | string | The target UID for permission change  |
 
+## VersionResponse
+The structure returned by a `Version` request. It contains the version information of the currently
+running encryptonize deployment.
+
+| Name      | Type   | Description                           |
+|-----------|--------|---------------------------------------|
+| commit    | string | Git commit hash                       |
+| tag       | string | Git commit tag (if any)               |
+
 # Authorization
 
 To authenticate a user should provide some metadata to the gRPC. The Metadata should consist of the
@@ -214,4 +224,12 @@ cannot reach the auth storage, in which case an error is returned.
 
 ```
 rpc CreateUser (CreateUserRequest) returns (CreateUserResponse)
+```
+
+# Get version of the running service
+
+Gets the commit hash and tag (if exists) of the currently running service.
+
+```
+rpc Version (VersionRequest) returns (VersionResponse)
 ```

--- a/documentation/manuals/user_manual.md
+++ b/documentation/manuals/user_manual.md
@@ -26,10 +26,11 @@ specification](../api/api-v2.md).
 1. [Storage](#storage)
     1. [Storing data](#storing-data)
     1. [Retrieving data](#retrieving-data)
-1. [Permissions](#decrypting)
+1. [Permissions](#permissions)
     1. [Get permissions of an object](#get-permissions-of-an-object)
     1. [Add permissions to an object](#add-permissions-to-an-object)
-    1. [Remove permissions from an object](#remove-permissions-from-an-object)
+    1. [Remove permissions from an object](#get-version-information)
+1. [Version](#version)
 1. [Troubleshooting](#troubleshooting)
     1. [Common Errors](#common-errors)
 
@@ -142,3 +143,6 @@ To add a user to the permission list of an object, you need to call the `AddPerm
 
 ## Remove permissions from an object
 To remove a user's permission from an object, you need to call the `RemovePermission` endpoint.
+
+# Version
+To get version information about the running encryption service, you need to call the `Version` endpoint. Currently, the endpoint returns the git commit hash and an optional git tag.

--- a/encryption-service/app/app.go
+++ b/encryption-service/app/app.go
@@ -30,6 +30,9 @@ import (
 	"encryption-service/objectstorage"
 )
 
+var GitCommit string
+var GitTag string
+
 type App struct {
 	Config               *Config
 	MessageAuthenticator *crypt.MessageAuthenticator

--- a/encryption-service/app/app.proto
+++ b/encryption-service/app/app.proto
@@ -35,8 +35,19 @@ service Encryptonize{
 
   // Removes permission from an object
   rpc RemovePermission (RemovePermissionRequest) returns (RemovePermissionResponse){}
+
+  // Returns the versions of the currently running services
+  rpc Version (VersionRequest) returns (VersionResponse){}
 }
 
+
+message VersionRequest{
+}
+
+message VersionResponse{
+  string commit = 1;
+  string tag = 2;
+}
 
 message StoreRequest{
   Object object = 1;

--- a/encryption-service/app/auth_handlers.go
+++ b/encryption-service/app/auth_handlers.go
@@ -44,6 +44,7 @@ var methodUserMap = map[string]authn.UserKindType{
 	baseMethodPath + "RemovePermission": authn.UserKind,
 	baseMethodPath + "Store":            authn.UserKind,
 	baseMethodPath + "Retrieve":         authn.UserKind,
+	baseMethodPath + "Version":          authn.UserKind,
 }
 
 // Inject full method name into unary call

--- a/encryption-service/app/version_handlers.go
+++ b/encryption-service/app/version_handlers.go
@@ -1,0 +1,23 @@
+// Copyright 2020 CYBERCRYPT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package app
+
+import "context"
+
+func (app *App) Version(ctx context.Context, request *VersionRequest) (*VersionResponse, error) {
+	return &VersionResponse{
+		Commit: GitCommit,
+		Tag:    GitTag,
+	}, nil
+}

--- a/encryption-service/app/version_handlers_test.go
+++ b/encryption-service/app/version_handlers_test.go
@@ -1,0 +1,40 @@
+// Copyright 2020 CYBERCRYPT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package app
+
+import (
+	"context"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	GitCommit = "3c9c1080d50ffd306213c3ea320e7856088d3ad8"
+	GitTag = "v2.0"
+
+	app := App{}
+
+	versionResponse, err := app.Version(context.Background(), &VersionRequest{})
+
+	if err != nil {
+		t.Fatalf("Failed to retrieve version: %v", err)
+	}
+
+	if versionResponse.Commit != GitCommit {
+		t.Fatalf("Version endpoint returned wrong commit. Expected: %v. Received: %v", GitCommit, versionResponse.Commit)
+	}
+
+	if versionResponse.Tag != GitTag {
+		t.Fatalf("Version endpoint returned wrong tag. Expected: %v. Received: %v", GitTag, versionResponse.Tag)
+	}
+}

--- a/encryption-service/encryption-service.dockerfile
+++ b/encryption-service/encryption-service.dockerfile
@@ -34,8 +34,9 @@ COPY . /encryption-service
 
 # Build binary
 ARG COMMIT
+ARG TAG
 ENV CGO_ENABLED=0
-RUN go build -v -ldflags "-X 'encryption-service/app.GitCommit=$COMMIT'" -o /go/bin/es main.go
+RUN go build -v -ldflags "-X 'encryption-service/app.GitCommit=$COMMIT' -X 'encryption-service/app.GitTag=$TAG'" -o /go/bin/es main.go
 
 # Adding the grpc_health_probe
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
@@ -47,7 +48,9 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
 FROM scratch
 
 ARG COMMIT
+ARG TAG
 LABEL git-commit=${COMMIT}
+LABEL git-tag=${TAG}
 
 COPY --from=build-env /go/bin/es /
 COPY --from=build-env /bin/grpc_health_probe /grpc_health_probe

--- a/encryption-service/scripts/docker_build.sh
+++ b/encryption-service/scripts/docker_build.sh
@@ -17,4 +17,5 @@
 set -euo pipefail
 
 COMMIT=$(git rev-list -1 HEAD)
-docker build --build-arg COMMIT=${COMMIT} -t encryptonize -f encryption-service.dockerfile .
+TAG=$(git tag --points-at HEAD)
+docker build --build-arg COMMIT="${COMMIT}" --build-arg TAG="${TAG}" -t encryptonize -f encryption-service.dockerfile .

--- a/encryption-service/scripts/docker_up.sh
+++ b/encryption-service/scripts/docker_up.sh
@@ -22,7 +22,7 @@
 set -euo pipefail
 
 # Start the docker containers
-docker-compose build --build-arg COMMIT=$(git rev-list -1 HEAD)
+docker-compose build --build-arg COMMIT="$(git rev-list -1 HEAD)" --build-arg TAG="$(git tag --points-at HEAD)"
 docker-compose up $@
 
 # Initialise the auth storage

--- a/encryption-service/tests/grpc_e2e_tests/client.go
+++ b/encryption-service/tests/grpc_e2e_tests/client.go
@@ -149,3 +149,14 @@ func (c *Client) CreateUser(usertype app.CreateUserRequest_UserKind) (*app.Creat
 	}
 	return createUserResponse, nil
 }
+
+// Perform a `Version` request.
+func (c *Client) GetVersion() (*app.VersionResponse, error) {
+	versionResponse, err := c.client.Version(c.ctx, &app.VersionRequest{})
+
+	if err != nil {
+		return nil, fmt.Errorf("Get version failed: %v", err)
+	}
+
+	return versionResponse, err
+}

--- a/encryption-service/tests/grpc_e2e_tests/grpc_e2e_version_test.go
+++ b/encryption-service/tests/grpc_e2e_tests/grpc_e2e_version_test.go
@@ -1,0 +1,31 @@
+// Copyright 2020 CYBERCRYPT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package grpce2e
+
+import "testing"
+
+// Test that the version endpoints works and returns a non-empty git commit hash
+func TestGetVersion(t *testing.T) {
+	client, err := NewClient(endpoint, uid, uat, https)
+	failOnError("Could not create client", err, t)
+	defer closeClient(client, t)
+
+	versionResponse, err := client.GetVersion()
+	failOnError("Getting version failed", err, t)
+
+	// Fail on no commit
+	if versionResponse.Commit == "" {
+		t.Fatal("Git commit is empty")
+	}
+}


### PR DESCRIPTION
### NOTE
This is a duplicate of PR #86 which squashes all changes into 1 signed commit. #86 will be deleted when this branch is merged.

### Description
This PR adds a version endpoint to the encryption server. At the moment the version will include the git commit hash and the git tag (if the commit is tagged). Other service versions can be added later to the protobuf VersionResponse message.

### Parent Issue
Issue #73 

### Comments for the Reviewers
Do we want to include more versioning information at the moment?

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [x] Added technical feature
- [x] Added tests
- [ ] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [x] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [x] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [x] I have updated relevant workflows and deployment tools.
- [x] I have updated/added relevant documentation (readme, doc comments, etc).
- [x] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
