### PR TITLE
added signed version of event parsing

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -511,6 +511,5 @@ settings:
   built-in Docker log parser.
 * Input.Mem_Buf_Limit = 5MB: The ammount of log data Fluentbit can hold at a time. The total
   throughput is therefore a function of this number and Service.Flush.
-* Output.Tls = on: We want encrypted connections.
-* Output.Tls.verify = off: We haven't yet distributed certificates to the Fluentbit agents, so we
-  cannot verify.
+* Filter.Name = es: We use kubernetes filters to enrich the logs with extra fields such as container and pod names. The filter is also configured with custom parsers for the object-store, auth-store and the encryption-service.
+* Filter.Merge_Parser = <parser>: Selects a parser which will be used to parse the contents of the "log" field (which is the stdout of the service). If the parser cannot match the content, it will skip parsing and the "log" field is preserved as is. Otherwise, the "log" field is split up into several fields. 

--- a/kubernetes/logging/fluent-bit-deploy.yaml
+++ b/kubernetes/logging/fluent-bit-deploy.yaml
@@ -151,17 +151,17 @@ data:
     [PARSER]
         name        encryption-service
         Format      regex
-        Regex       level=(?<level>[^ ]+) msg=\"(?<message>.*)\" Method=(?<method>[^ ]+) Status=(?<status>[^ ]+) UserID=(?<userId>[^ ]*)
+        Regex       level=(?<level>[^ ]+) msg=\"(?<message>[^\"]*)\" Method=(?<method>[^ ]+) Status=(?<status>[^ ]+) UserID=(?<userId>[^ ]*)
 
     [PARSER]
         name       object-store
         Format     regex
-        Regex      beast: [^ ]+ [^ ]+ [^ ]+ [^ ]+ [^ ]+ \"(?<method>[^ ]+) (?<endpoint>[^ ]+) [^ ]+ (?<status>[^ ]+) [^ ]+ [^ ]+ \"(?<useragent>.*)\"
+        Regex      beast: [^ ]+ [^ ]+ [^ ]+ [^ ]+ [^ ]+ \"(?<method>[^ ]+) (?<endpoint>[^ ]+) [^ ]+ (?<status>[^ ]+) [^ ]+ [^ ]+ \"(?<useragent>[^\"]*)\"
 
     [PARSER]
         name       auth-store
         Format     regex
-        Regex      ^[^ ]+ ^[^ ]+.+\{\"(?<table>[^ ]+)\"\[[0-9]+\]:(?<operation>[^ ]+)\} \".+\".+} [^ ]+ [^ ]+ (?<status>[^ ]+)
+        Regex      ^[^ ]+ [^ ]+[^\{]+\{\"(?<table>[^ ]+)\"\[[0-9]+\]:(?<operation>[^ ]+)\} \"[^\"]+\"[^\}]+\} [^ ]+ [^ ]+ (?<status>[^ ]+)
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/kubernetes/logging/fluent-bit-deploy.yaml
+++ b/kubernetes/logging/fluent-bit-deploy.yaml
@@ -31,24 +31,64 @@ data:
 
     [INPUT]
         Name              tail
-        Tag               kube.*
-        Path              /var/log/containers/encryptonize*.log,/var/log/containers/cockroachdb*.log,/var/log/containers/rook-ceph-osd*.log
+        Tag               encryptonize.encryption-service.*
+        Path              /var/log/containers/encryptonize-deployment*.log
         Parser            docker
-        DB                /var/log/flb_kube.db
+        DB                /var/log/encryptonize.db
+        Mem_Buf_Limit     5MB
+        Skip_Long_Lines   Off
+        Refresh_Interval  10
+
+    [INPUT]
+        Name              tail
+        Tag               encryptonize.auth-store.*
+        Path              /var/log/containers/cockroachdb*.log
+        Parser            docker
+        DB                /var/log/encryptonize.db
+        Mem_Buf_Limit     5MB
+        Skip_Long_Lines   Off
+        Refresh_Interval  10
+
+    [INPUT]
+        Name              tail
+        Tag               encryptonize.object-store.*
+        Path              /var/log/containers/rook-ceph-rgw*.log
+        Parser            docker
+        DB                /var/log/encryptonize.db
         Mem_Buf_Limit     5MB
         Skip_Long_Lines   Off
         Refresh_Interval  10
 
     [FILTER]
         Name                kubernetes
-        Match               kube.*
+        Match               encryptonize.auth-store.*
         Kube_URL            https://kubernetes.default.svc.cluster.local:443
-        Merge_Log           Off
-        K8S-Logging.Parser  On
+        Kube_Tag_Prefix     encryptonize.auth-store.var.log.containers.
+        Merge_Log           On
+        Merge_Parser        auth-store
+        Keep_Log            Off 
 
+    [FILTER]
+        Name                kubernetes
+        Match               encryptonize.object-store.*
+        Kube_URL            https://kubernetes.default.svc.cluster.local:443
+        Kube_Tag_Prefix     encryptonize.object-store.var.log.containers.
+        Merge_Log           On
+        Merge_Parser        object-store
+        Keep_Log            Off
+
+    [FILTER]
+        Name                kubernetes
+        Match               encryptonize.encryption-service.*
+        Kube_URL            https://kubernetes.default.svc.cluster.local:443
+        Kube_Tag_Prefix     encryptonize.encryption-service.var.log.containers.
+        Merge_Log           On
+        Merge_Parser        encryption-service
+        Keep_Log            Off
+        
     [OUTPUT]
         Name            es
-        Match           *
+        Match           encryptonize.*
         Host            ${FLUENT_ELASTICSEARCH_HOST}
         Port            ${FLUENT_ELASTICSEARCH_PORT}
         HTTP_User       ${FLUENT_ELASTICSEARCH_USER}
@@ -107,6 +147,21 @@ data:
         Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
         Time_Key    time
         Time_Format %b %d %H:%M:%S
+
+    [PARSER]
+        name        encryption-service
+        Format      regex
+        Regex       level=(?<level>[^ ]+) msg=\"(?<message>.*)\" Method=(?<method>[^ ]+) Status=(?<status>[^ ]+) UserID=(?<userId>[^ ]*)
+
+    [PARSER]
+        name       object-store
+        Format     regex
+        Regex      beast: [^ ]+ [^ ]+ [^ ]+ [^ ]+ [^ ]+ \"(?<method>[^ ]+) (?<endpoint>[^ ]+) [^ ]+ (?<status>[^ ]+) [^ ]+ [^ ]+ \"(?<useragent>.*)\"
+
+    [PARSER]
+        name       auth-store
+        Format     regex
+        Regex      ^[^ ]+ ^[^ ]+.+\{\"(?<table>[^ ]+)\"\[[0-9]+\]:(?<operation>[^ ]+)\} \".+\".+} [^ ]+ [^ ]+ (?<status>[^ ]+)
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
### NOTE
This PR is (almost) a copy of #77. It is created to include my signature on the commit. #77 and it's branch will be deleted. The only change in this PR is that the `logtime` keyword is removed from the parsers, as the timestamp is already included in the kubernetes metadata.

### Description
This PR adds custom fluentbit parsers for auth-store, object-store and encryption-server logs. Custom parsing allows us to extract interesting fields which can be translated to informative dashboards and consumed by IDS and SIEM software.

### Parent Issue
Issue #59, #48 

### Comments for the Reviewers
You can browse through logs and keywords in Kibana (see 1pass for credentials. You have to port-forward thorugh kubectl to gain access). Play arround with logs under "Kibana" -> "Dashboards" or view an example of encryptonize operations dashboard under "Kibana" -> "Dashboards".

The regex expressions use the [rubular](https://rubular.com/) syntax. A good understanding of regex is required in order to understand the parsers. 

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [x] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools. N/A
- [x] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files. N/A
- [x] I have spent some time looking over the full diff before creating this PR.
