### PR TITLE
Add object access log

### DIFF
--- a/encryption-service/app/permissions_handler.go
+++ b/encryption-service/app/permissions_handler.go
@@ -49,6 +49,9 @@ func (app *App) GetPermissions(ctx context.Context, request *GetPermissionsReque
 		return nil, status.Errorf(codes.Internal, "error encountered while getting permissions")
 	}
 
+	ctx = context.WithValue(ctx, contextkeys.ObjectIDCtxKey, request.ObjectId)
+	log.Info(ctx, "GetPermissions: Permission added")
+
 	return &GetPermissionsResponse{UserIds: uids}, nil
 }
 
@@ -100,6 +103,9 @@ func (app *App) AddPermission(ctx context.Context, request *AddPermissionRequest
 		return nil, status.Errorf(codes.Internal, "error encountered while adding permission")
 	}
 
+	ctx = context.WithValue(ctx, contextkeys.ObjectIDCtxKey, oid)
+	log.Info(ctx, "AddPermission: Permission added")
+
 	return &AddPermissionResponse{}, nil
 }
 
@@ -137,6 +143,9 @@ func (app *App) RemovePermission(ctx context.Context, request *RemovePermissionR
 		log.Error(ctx, "RemovePermission: Failed to commit auth storage transaction", err)
 		return nil, status.Errorf(codes.Internal, "error encountered while removing permission")
 	}
+
+	ctx = context.WithValue(ctx, contextkeys.ObjectIDCtxKey, oid)
+	log.Info(ctx, "RemovePermission: Permission removed")
 
 	return &RemovePermissionResponse{}, nil
 }

--- a/encryption-service/app/permissions_handler.go
+++ b/encryption-service/app/permissions_handler.go
@@ -104,6 +104,7 @@ func (app *App) AddPermission(ctx context.Context, request *AddPermissionRequest
 	}
 
 	ctx = context.WithValue(ctx, contextkeys.ObjectIDCtxKey, oid)
+	ctx = context.WithValue(ctx, contextkeys.TargetIDCtxKey, target)
 	log.Info(ctx, "AddPermission: Permission added")
 
 	return &AddPermissionResponse{}, nil
@@ -145,6 +146,7 @@ func (app *App) RemovePermission(ctx context.Context, request *RemovePermissionR
 	}
 
 	ctx = context.WithValue(ctx, contextkeys.ObjectIDCtxKey, oid)
+	ctx = context.WithValue(ctx, contextkeys.TargetIDCtxKey, target)
 	log.Info(ctx, "RemovePermission: Permission removed")
 
 	return &RemovePermissionResponse{}, nil

--- a/encryption-service/app/storage_handlers.go
+++ b/encryption-service/app/storage_handlers.go
@@ -79,6 +79,10 @@ func (app *App) Store(ctx context.Context, request *StoreRequest) (*StoreRespons
 		log.Error(ctx, "Store: Failed to commit auth storage transaction", err)
 		return nil, status.Errorf(codes.Internal, "error encountered while storing object")
 	}
+
+	ctx = context.WithValue(ctx, contextkeys.ObjectIDCtxKey, objectIDString)
+	log.Info(ctx, "Store: Object stored")
+
 	return &StoreResponse{ObjectId: objectIDString}, nil
 }
 
@@ -118,6 +122,9 @@ func (app *App) Retrieve(ctx context.Context, request *RetrieveRequest) (*Retrie
 		log.Error(ctx, "Retrieve: Failed to decrypt object", err)
 		return nil, status.Errorf(codes.Internal, "error encountered while retrieving object")
 	}
+
+	ctx = context.WithValue(ctx, contextkeys.ObjectIDCtxKey, objectIDString)
+	log.Info(ctx, "Retrieve: Object retrieved")
 
 	return &RetrieveResponse{
 		Object: &Object{

--- a/encryption-service/contextkeys/contextkeys.go
+++ b/encryption-service/contextkeys/contextkeys.go
@@ -22,4 +22,5 @@ const (
 	StatusCtxKey
 	AuthStorageCtxKey
 	ObjectIDCtxKey
+	TargetIDCtxKey
 )

--- a/encryption-service/contextkeys/contextkeys.go
+++ b/encryption-service/contextkeys/contextkeys.go
@@ -21,4 +21,5 @@ const (
 	MethodNameCtxKey
 	StatusCtxKey
 	AuthStorageCtxKey
+	ObjectIDCtxKey
 )

--- a/encryption-service/logger/logger.go
+++ b/encryption-service/logger/logger.go
@@ -63,6 +63,11 @@ func fieldsFromCtx(ctx context.Context) log.Fields {
 		fields["objectId"] = objectID
 	}
 
+	targetID := ctx.Value(contextkeys.TargetIDCtxKey)
+	if targetID != nil {
+		fields["targetId"] = targetID
+	}
+
 	return fields
 }
 

--- a/encryption-service/logger/logger.go
+++ b/encryption-service/logger/logger.go
@@ -58,6 +58,11 @@ func fieldsFromCtx(ctx context.Context) log.Fields {
 		fields["status"] = status
 	}
 
+	objectID := ctx.Value(contextkeys.ObjectIDCtxKey)
+	if objectID != nil {
+		fields["objectId"] = objectID
+	}
+
 	return fields
 }
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -307,7 +307,7 @@ kubectl -n rook-ceph get secret ingress-certificate -o jsonpath="{.data['tls\.cr
 
 Connect `kubectl` to the CockroachDB cluster and retrieve the CA certificate, client certificate, and client key:
 ```bash
-kubectl -n cockroachdb exec -it cockroachdb-0 -- cat /cockroach/cockroach-certs/ca.crt  > ./encryptonize-secrets/ca.crt
+kubectl -n cockroachdb exec -it cockroachdb-0 -- cat /cockroach/cockroach-certs/ca.crt -c cockroachdb  > ./encryptonize-secrets/ca.crt
 kubectl -n cockroachdb get secrets cockroachdb.client.root -o jsonpath='{.data.cert}' | base64 -d > ./encryptonize-secrets/client.root.crt
 touch ./encryptonize-secrets/client.root.key && chmod 600 ./encryptonize-secrets/client.root.key
 kubectl -n cockroachdb get secrets cockroachdb.client.root -o jsonpath='{.data.key}' | base64 -d > ./encryptonize-secrets/client.root.key

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -271,13 +271,18 @@ kubectl apply -f object-storage/operator.yaml
 kubectl apply -f object-storage/cluster.yaml
 kubectl apply -f object-storage/object.yaml
 kubectl apply -f object-storage/ingress.yaml
-kubectl patch deployment rook-ceph-rgw-encryptonize-store-a -n rook-ceph --patch "$(cat object-storage/rgw-patch.yaml)"
 ```
 
 Wait for everything to finish. You should see three `rook-ceph-osd` pods eventually (takes about 5
 minutes):
 ```bash
 watch kubectl -n rook-ceph get pod
+```
+
+At last you have to apply the following patch in order to enable ceph audit logs:
+
+```bash
+kubectl patch deployment rook-ceph-rgw-encryptonize-store-a -n rook-ceph --patch "$(cat object-storage/rgw-patch.yaml)"
 ```
 
 ## Encryption Service Deployment

--- a/kubernetes/object-storage/ingress.yaml
+++ b/kubernetes/object-storage/ingress.yaml
@@ -66,11 +66,11 @@ data:
         ssl_prefer_server_ciphers off;
 
         location /nginx-health {
-	  proxy_http_version 1.1;
+          proxy_http_version 1.1;
           return 200 "healthy\n";
         }
         location / {
-	  proxy_http_version 1.1;
+          proxy_http_version 1.1;
           proxy_set_header Host '${OBJECT_STORAGE_HOSTNAME}';
           proxy_pass http://rook-ceph-rgw-encryptonize-store.rook-ceph.svc.cluster.local:80;
         }

--- a/kubernetes/object-storage/ingress.yaml
+++ b/kubernetes/object-storage/ingress.yaml
@@ -66,9 +66,11 @@ data:
         ssl_prefer_server_ciphers off;
 
         location /nginx-health {
+	  proxy_http_version 1.1;
           return 200 "healthy\n";
         }
         location / {
+	  proxy_http_version 1.1;
           proxy_set_header Host '${OBJECT_STORAGE_HOSTNAME}';
           proxy_pass http://rook-ceph-rgw-encryptonize-store.rook-ceph.svc.cluster.local:80;
         }


### PR DESCRIPTION
### Description
This PR enriches some of our log statements with an object ID. This enables us to trace access to objects and permissions. Note that the tracing information is stored in elasticsearch rather than the database as originally intended.

### Parent Issue
Issue #46 

### Comments for the Reviewers
- Check that we have all the information we need to track users access to objects and permissions. This branch is currently deployed on staging, so elasticsearch should contain the updated logs.
- I have attached a small example from Kibana on how we can view access to objects with current implementation.

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [x] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.