### PR TITLE
Integrate eccs tests int 'make tests'

### DIFF
--- a/.github/workflows/encryption-service-build.yaml
+++ b/.github/workflows/encryption-service-build.yaml
@@ -26,53 +26,6 @@ jobs:
     - name: Build
       run: make build
 
-  esb-unit-test:
-    needs: esb-build
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/cyber-crypt-com/github-runner:1.1
-      credentials:
-        username: USERNAME
-        password: ${{ secrets.GHCR_PULL_TOKEN }}
-
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v2
-
-    - name: Test
-      run: make unit-tests
-
-  esb-end-to-end:
-    needs: esb-build
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/cyber-crypt-com/github-runner:1.1
-      credentials:
-        username: USERNAME
-        password: ${{ secrets.GHCR_PULL_TOKEN }}
-
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v2
-
-    - name: Start docker containers
-      run: make docker-up
-
-    - name: Run end-to-end tests
-      # Small hack to get docker-compose next to docker to work. We cannot attach to the host
-      # network due to the way the workflow container is started, so we fetch the ip of the docker0
-      # interface instead. See https://stackoverflow.com/a/31328031 for more information.
-      run: |
-        export E2E_TEST_URL=$(ip route show | awk '/default/ {print $3}'):9000
-        make e2e-tests
-
-    - name: Log on failure
-      if: ${{ failure() }}
-      run: docker-compose logs
-
-    - name: Stop docker containers
-      run: make docker-down
-
   esb-eccs-build:
     runs-on: ubuntu-latest
     container:
@@ -94,7 +47,23 @@ jobs:
     - name: Build
       run: make build
 
-  esb-eccs-test:
+  esb-unit-test:
+    needs: esb-build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/cyber-crypt-com/github-runner:1.1
+      credentials:
+        username: USERNAME
+        password: ${{ secrets.GHCR_PULL_TOKEN }}
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Test
+      run: make unit-tests
+
+  esb-end-to-end-and-eccs:
     needs: [esb-build, esb-eccs-build]
     runs-on: ubuntu-latest
     container:
@@ -116,8 +85,12 @@ jobs:
       # interface instead. See https://stackoverflow.com/a/31328031 for more information.
       run: |
         export ECCS_ENDPOINT=$(ip route show | awk '/default/ {print $3}'):9000
-        make tests
-      working-directory: applications/ECCS
+        make eccs-tests
+
+    - name: Run end-to-end tests
+      run: |
+        export E2E_TEST_URL=$(ip route show | awk '/default/ {print $3}'):9000
+        make e2e-tests
 
     - name: Log on failure
       if: ${{ failure() }}

--- a/applications/ECCS/makefile
+++ b/applications/ECCS/makefile
@@ -37,7 +37,7 @@ lint: $(protobufs)  ## Lint the codebase
 
 ##### Test targets #####
 .PHONY: tests
-tests: build
+tests: build        ## Run function tests
 	./scripts/function_tests.py
 
 

--- a/encryption-service/makefile
+++ b/encryption-service/makefile
@@ -53,7 +53,7 @@ lint: $(protobufs)  ## Lint the codebase
 
 ##### Test targets #####
 .PHONY: tests
-tests: unit-tests e2e-tests  ## Run all tests
+tests: unit-tests e2e-tests eccs-tests ## Run all tests
 
 .PHONY: coverage
 coverage: build  ## Generate coverage report
@@ -66,6 +66,10 @@ unit-tests: build  ## Run unit tests
 .PHONY: e2e-tests
 e2e-tests: build  ## Run end-to-end tests
 	./scripts/e2e_tests.sh
+
+.PHONY: eccs-tests
+eccs-tests: build
+	$(MAKE) -C ../applications/ECCS tests
 
 
 ##### Run targets #####

--- a/encryption-service/makefile
+++ b/encryption-service/makefile
@@ -68,7 +68,7 @@ e2e-tests: build  ## Run end-to-end tests
 	./scripts/e2e_tests.sh
 
 .PHONY: eccs-tests
-eccs-tests: build
+eccs-tests: build ## Run tests of the ECCS application
 	$(MAKE) -C ../applications/ECCS tests
 
 


### PR DESCRIPTION
for ease of use you should only need to run 'make tests' once. Thus the eccs tests should also be performed at the same time end to end tests are. They have the same requirements.

### Description
- (Context the reviewer might need to know)
- (What changes does this PR introduce)
- (How were these changes implemented)

### Parent Issue
Closes #94

### Related Pull Requests
PR #103

### Comments for the Reviewers
- eccs tests are integrated as a recursive make call to the correct makefile
- the requirements for eccs and e2e tests are almost identical (eccs additionally requires only eccs-build)

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [x] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [x] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [ ] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.