### PR TITLE
changed value of 'method' from rgw log

### DIFF
--- a/kubernetes/logging/fluent-bit-deploy.yaml
+++ b/kubernetes/logging/fluent-bit-deploy.yaml
@@ -95,7 +95,7 @@ data:
     [FILTER]
         Name                modify
         Match               encryptonize.object-store.*
-        Rename              uri method
+        Rename              operation method
         Rename              http_status status
         
     [OUTPUT]


### PR DESCRIPTION
### Description
Small change to our logging scraper place the "operation" content from ceph audit logs into the "method" keyword so it is in line with the "method" from encryption service and CDB.