### PR TITLE
added switch to not use json when logging to a tty

### DIFF
--- a/encryption-service/logger/logger.go
+++ b/encryption-service/logger/logger.go
@@ -32,6 +32,11 @@ func init() {
 	log.SetOutput(os.Stderr)
 	log.SetLevel(log.DebugLevel)
 	log.SetFormatter(&log.JSONFormatter{})
+	if stderrInfo, err := os.Stderr.Stat(); err == nil {
+		if (stderrInfo.Mode() & os.ModeCharDevice) != 0 {
+			log.SetFormatter(&log.TextFormatter{})
+		}
+	}
 }
 
 // Extracts logging fields from context. Does not set a field if it is not present in the context.


### PR DESCRIPTION
### Description
When running the encryption server log messages should be easy to read. For that reason
log messages or not formatted in JSON if stderr is a character device

### Parent Issue
Closes #114 

### Comments for the Reviewers
- I did not want to assume that text formatting is set by default.

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [x] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.