### PR TITLE
make docker allocate a tty

### DIFF
--- a/encryption-service/docker-compose.yml
+++ b/encryption-service/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - cockroachdb-2
       - cockroachdb-3
       - minio
+    tty: true
 
   # CockroachDB
   cockroachdb-1:


### PR DESCRIPTION
### Description
for better logs when using docker-up docker should allocate a tty

### Parent Issue
Issue #114 

### Related Pull Requests
PR #115 

### Comments for the Reviewers
nil

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [x] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [ ] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.