### PR TITLE
Allow for messages of up to 64MiB

### DIFF
--- a/encryption-service/app/app.go
+++ b/encryption-service/app/app.go
@@ -230,7 +230,7 @@ func (app *App) initgRPC(port int) (*grpc.Server, net.Listener) {
 	// The order is important: AuthenticateUser needs AuthStore and Authstore needs MethodName
 	// TODO: make sure that grpc_recovery doesn't leak any infos
 	grpcServer := grpc.NewServer(
-		grpc.MaxMsgSize(65*1024*1024),
+		grpc.MaxRecvMsgSize(65*1024*1024),
 		grpc_middleware.WithUnaryServerChain(
 			grpc_recovery.UnaryServerInterceptor(),
 			log.UnaryRequestIDInterceptor(),

--- a/encryption-service/app/app.go
+++ b/encryption-service/app/app.go
@@ -230,6 +230,7 @@ func (app *App) initgRPC(port int) (*grpc.Server, net.Listener) {
 	// The order is important: AuthenticateUser needs AuthStore and Authstore needs MethodName
 	// TODO: make sure that grpc_recovery doesn't leak any infos
 	grpcServer := grpc.NewServer(
+		grpc.MaxMsgSize(65*1024*1024),
 		grpc_middleware.WithUnaryServerChain(
 			grpc_recovery.UnaryServerInterceptor(),
 			log.UnaryRequestIDInterceptor(),

--- a/encryption-service/scripts/run_in_mem.sh
+++ b/encryption-service/scripts/run_in_mem.sh
@@ -21,6 +21,9 @@ set -euo pipefail
 #
 # The environment variables below can be set to modify the configuration of the service.
 
+# Static compilation
+export CGO_ENABLED=0
+
 # testing keys never deploy them!
 export KEK=0000000000000000000000000000000000000000000000000000000000000000
 export ASK=0000000000000000000000000000000000000000000000000000000000000001

--- a/kubernetes/encryption-service/encryptonize-ingress.yaml
+++ b/kubernetes/encryption-service/encryptonize-ingress.yaml
@@ -71,7 +71,7 @@ data:
         location / {
           grpc_pass grpc://encryptonize-service.encryptonize.svc.cluster.local:9000;
         }
-        client_max_body_size 65M;
+        client_max_body_size 100M;
       }
     }
 ---

--- a/kubernetes/encryption-service/encryptonize-ingress.yaml
+++ b/kubernetes/encryption-service/encryptonize-ingress.yaml
@@ -71,7 +71,7 @@ data:
         location / {
           grpc_pass grpc://encryptonize-service.encryptonize.svc.cluster.local:9000;
         }
-        client_max_body_size 5M;
+        client_max_body_size 65M;
       }
     }
 ---

--- a/kubernetes/object-storage/ingress.yaml
+++ b/kubernetes/object-storage/ingress.yaml
@@ -74,7 +74,7 @@ data:
           proxy_set_header Host '${OBJECT_STORAGE_HOSTNAME}';
           proxy_pass http://rook-ceph-rgw-encryptonize-store.rook-ceph.svc.cluster.local:80;
         }
-        client_max_body_size 5M;
+        client_max_body_size 65M;
       }
     }
 ---

--- a/kubernetes/object-storage/ingress.yaml
+++ b/kubernetes/object-storage/ingress.yaml
@@ -74,7 +74,7 @@ data:
           proxy_set_header Host '${OBJECT_STORAGE_HOSTNAME}';
           proxy_pass http://rook-ceph-rgw-encryptonize-store.rook-ceph.svc.cluster.local:80;
         }
-        client_max_body_size 65M;
+        client_max_body_size 100M;
       }
     }
 ---


### PR DESCRIPTION
### Description
This PR changes our message size limit to allow for messages of up to 64 MiB. The actual limit on the server and the two ingresses are set to 65 MiB to allow for some overhead on the messages. 

### Parent Issue
#98 

### Related Pull Requests
None

### Comments for the Reviewers
Any considerations I overlooked? 

### Type(s) of Change (Split the PR if you check many)
- [x] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [x] I have added/updated unit tests for functional changes.
- [x] I have added/updated integration tests for changes that affect dependent systems.
- [x] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [x] I have updated relevant workflows and deployment tools.
- [x] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
