### PR TITLE
added Server Reflection

### DIFF
--- a/encryption-service/app/app.go
+++ b/encryption-service/app/app.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -35,6 +36,7 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	grpc_reflection "google.golang.org/grpc/reflection"
 	status "google.golang.org/grpc/status"
 
 	"encryption-service/authn"
@@ -238,7 +240,10 @@ func (app *App) initgRPC(port int) (*grpc.Server, net.Listener) {
 	// make gprc_recovery log panics and return generic errors to the caller
 	recoveryOpt := grpc_recovery.WithRecoveryHandlerContext(
 		func(ctx context.Context, p interface{}) error {
-			log.Error(ctx, "panic recovered", fmt.Errorf("panic: %v", p))
+			stack := make([]byte, 4096)
+			runtime.Stack(stack, false)
+			msg := fmt.Sprintf("panic recoverd: \n\n%s\n", stack)
+			log.Error(ctx, msg, fmt.Errorf("panic: %v", p))
 			return status.Errorf(codes.Internal, "internal error")
 		},
 	)
@@ -287,6 +292,9 @@ func (app *App) initgRPC(port int) (*grpc.Server, net.Listener) {
 	// Register health checker to grpc server
 	healthService := health.NewHealthChecker()
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthService)
+
+	// Register grpc reflection handler
+	grpc_reflection.Register(grpcServer)
 
 	return grpcServer, lis
 }

--- a/encryption-service/authn/authn.go
+++ b/encryption-service/authn/authn.go
@@ -70,7 +70,7 @@ func (au *AuthService) CheckAccessToken(ctx context.Context) (context.Context, e
 
 	// Don't authenticate health checks
 	// IMPORTANT! This check MUST stay at the top of this function
-	if methodName == health.HealthEndpointCheck || methodName == health.HealthEndpointWatch {
+	if methodName == health.HealthEndpointCheck || methodName == health.HealthEndpointWatch || methodName == health.ReflectionEndpoint {
 		return ctx, nil
 	}
 

--- a/encryption-service/authstorage/authstorage_middleware.go
+++ b/encryption-service/authstorage/authstorage_middleware.go
@@ -78,7 +78,7 @@ func (as *AuthStore) AuthStorageStreamingInterceptor() grpc.StreamServerIntercep
 		// Don't start DB transaction on health checks
 		// IMPORTANT! This check MUST stay at the top of this function
 		if methodName == health.HealthEndpointCheck || methodName == health.HealthEndpointWatch || methodName == health.ReflectionEndpoint {
-			return handler(ctx, stream)
+			return handler(srv, stream)
 		}
 
 		authStoreTx, err := as.NewTransaction(ctx)

--- a/encryption-service/authstorage/authstorage_middleware.go
+++ b/encryption-service/authstorage/authstorage_middleware.go
@@ -41,7 +41,7 @@ func (as *AuthStore) AuthStorageUnaryServerInterceptor() grpc.UnaryServerInterce
 
 		// Don't start DB transaction on health checks
 		// IMPORTANT! This check MUST stay at the top of this function
-		if methodName == health.HealthEndpointCheck || methodName == health.HealthEndpointWatch {
+		if methodName == health.HealthEndpointCheck || methodName == health.HealthEndpointWatch || methodName == health.ReflectionEndpoint {
 			return handler(ctx, req)
 		}
 
@@ -67,6 +67,19 @@ func (as *AuthStore) AuthStorageUnaryServerInterceptor() grpc.UnaryServerInterce
 func (as *AuthStore) AuthStorageStreamingInterceptor() grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := stream.Context()
+
+		methodName, ok := ctx.Value(contextkeys.MethodNameCtxKey).(string)
+		if !ok {
+			err := status.Errorf(codes.Internal, "error encountered while connecting to auth storage")
+			log.Error(ctx, "Could not typecast methodName to string", err)
+			return err
+		}
+
+		// Don't start DB transaction on health checks
+		// IMPORTANT! This check MUST stay at the top of this function
+		if methodName == health.HealthEndpointCheck || methodName == health.HealthEndpointWatch || methodName == health.ReflectionEndpoint {
+			return handler(ctx, stream)
+		}
 
 		authStoreTx, err := as.NewTransaction(ctx)
 		if err != nil {

--- a/encryption-service/health/health.go
+++ b/encryption-service/health/health.go
@@ -22,6 +22,7 @@ import (
 const (
 	HealthEndpointCheck string = "/grpc.health.v1.Health/Check"
 	HealthEndpointWatch string = "/grpc.health.v1.Health/Watch"
+	ReflectionEndpoint  string = "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
 )
 
 type Checker struct{}

--- a/encryption-service/logger/logger.go
+++ b/encryption-service/logger/logger.go
@@ -183,13 +183,12 @@ func UnaryLogInterceptor() grpc.UnaryServerInterceptor {
 // Logging interceptor for stream calls
 func StreamLogInterceptor() grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		log.Infof("srv: %v, stream: %v, info: %v", srv, stream, info)
+		ctx := stream.Context()
+		Info(ctx, "Request start")
 
-		var newCtx context.Context
-		wrapped := grpc_middleware.WrapServerStream(stream)
-		wrapped.WrappedContext = newCtx
-		err := handler(srv, wrapped)
+		err := handler(srv, stream)
 
+		Info(ctx, "Request completed")
 		return err
 	}
 }

--- a/encryption-service/logger/logger.go
+++ b/encryption-service/logger/logger.go
@@ -188,6 +188,12 @@ func StreamLogInterceptor() grpc.StreamServerInterceptor {
 
 		err := handler(srv, stream)
 
+		status := "success"
+		if err != nil {
+			status = "failure"
+		}
+
+		ctx = context.WithValue(stream.Context(), contextkeys.StatusCtxKey, status)
 		Info(ctx, "Request completed")
 		return err
 	}


### PR DESCRIPTION
### Description
While learning and playing with gRPC i looked into Server Reflection after Philip mentioning it to be potentially interesting.
Trying to deploy them I ran into a bug with the Streaming Interceptor. This Issue fixes that bug and also adds the Server Reflection

### Comments for the Reviewers
- Added a stack trace to the panic recovery
- We may want to change the checks against the public APIs (health + Reflection)
- Test with `grpcurl -plaintext 127.0.0.1:9000 list` and `grpcurl -plaintext 127.0.0.1:9000 describe`

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [X] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [X] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [x] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.