### PR TITLE
Make MessageAuthenticator instances domain specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![es build](https://github.com/cyber-crypt-com/encryptonize-core/workflows/Encryption%20service%20build/badge.svg)
 ![es deploy](https://github.com/cyber-crypt-com/encryptonize-core/workflows/Encryption%20service%20deploy/badge.svg)
--[![Go Report Card](https://goreportcard.com/badge/github.com/cyber-crypt-com/encryptonize-core)](https://goreportcard.com/report/github.com/cyber-crypt-com/encryptonize-core)
+[![Go Report Card](https://goreportcard.com/badge/github.com/cyber-crypt-com/encryptonize-core)](https://goreportcard.com/report/github.com/cyber-crypt-com/encryptonize-core)
 
 <img src="documentation/imgs/rook-hex.png" alt="Encryptonize" width="250"/>
 
@@ -23,7 +23,7 @@ of a multi cloud setup. It is designed to not only encrypt and authenticate your
 cryptographic standards, but also to cryptographically enforce user authentication and
 authorization.
 
-## Achitecture overview
+## Architecture overview
 
 At the core, Enryptonize&reg; consists of an Encryption Service (ES). In future releases of
 Enryptonize&reg; a Key Service will be added to automatically handle distribution of key material to
@@ -64,8 +64,8 @@ For more details, see the [Encryption Service README](encryption-service/README.
 # Deploying Encryptonize&reg; Core
 
 We supply Kubernetes files for deploying the full Encryptonize&reg; setup in a basic configuration.
-The files can be found in the [`kubernetes`](kubernetes) folder. For instructions on how to deploy, see that
-[deployment README](kubernetes/README.md)
+The files can be found in the [`kubernetes`](kubernetes) folder. For instructions on how to deploy,
+see the [deployment README](kubernetes/README.md)
 
 
 # Repository overview

--- a/encryption-service/app/app.go
+++ b/encryption-service/app/app.go
@@ -50,12 +50,12 @@ var GitCommit string
 var GitTag string
 
 type App struct {
-	Config               *Config
-	MessageAuthenticator *crypt.MessageAuthenticator
-	AuthService          authn.AuthServiceInterface
-	AuthStore            authstorage.AuthStoreInterface
-	ObjectStore          objectstorage.ObjectStoreInterface
-	Crypter              crypt.CrypterInterface
+	Config          *Config
+	AccessObjectMAC *crypt.MessageAuthenticator
+	AuthService     authn.AuthServiceInterface
+	AuthStore       authstorage.AuthStoreInterface
+	ObjectStore     objectstorage.ObjectStoreInterface
+	Crypter         crypt.CrypterInterface
 	UnimplementedEncryptonizeServer
 }
 

--- a/encryption-service/app/authz_handlers.go
+++ b/encryption-service/app/authz_handlers.go
@@ -31,7 +31,7 @@ import (
 // Wraps the Authorize call
 // Fails if uid or oid are wrongly formatted
 // or if a user isn't authorized to edit the accessObject
-func AuthorizeWrapper(ctx context.Context, messageAuthenticator *crypt.MessageAuthenticator, objectIDString string) (*authz.Authorizer, *authz.AccessObject, error) {
+func AuthorizeWrapper(ctx context.Context, accessObjectMAC *crypt.MessageAuthenticator, objectIDString string) (*authz.Authorizer, *authz.AccessObject, error) {
 	//Define authorizer struct
 	authStorageTx, ok := ctx.Value(contextkeys.AuthStorageTxCtxKey).(authstorage.AuthStoreTxInterface)
 	if !ok {
@@ -41,8 +41,8 @@ func AuthorizeWrapper(ctx context.Context, messageAuthenticator *crypt.MessageAu
 	}
 
 	authorizer := &authz.Authorizer{
-		MessageAuthenticator: messageAuthenticator,
-		AuthStoreTx:          authStorageTx,
+		AccessObjectMAC: accessObjectMAC,
+		AuthStoreTx:     authStorageTx,
 	}
 	userID, ok := ctx.Value(contextkeys.UserIDCtxKey).(uuid.UUID)
 	if !ok {

--- a/encryption-service/app/authz_handlers_test.go
+++ b/encryption-service/app/authz_handlers_test.go
@@ -42,7 +42,7 @@ func failOnSuccess(message string, err error, t *testing.T) {
 
 func CreateUserForTests(m *crypt.MessageAuthenticator, userID uuid.UUID, scopes authn.ScopeType) (string, error) {
 	authenticator := &authn.AuthService{
-		MessageAuthenticator: m,
+		TokenMAC: m,
 	}
 
 	accessToken := &authn.AccessToken{
@@ -83,7 +83,7 @@ func TestAuthorizeWrapper(t *testing.T) {
 		},
 	}
 
-	messageAuthenticator, err := crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+	messageAuthenticator, err := crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), crypt.AccessObjectsDomain)
 	failOnError("NewMessageAuthenticator errored", err, t)
 
 	ctx := context.WithValue(context.Background(), contextkeys.UserIDCtxKey, userID)
@@ -125,7 +125,7 @@ func TestAuthorizeWrapperUnauthorized(t *testing.T) {
 		},
 	}
 
-	messageAuthenticator, err := crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+	messageAuthenticator, err := crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), crypt.AccessObjectsDomain)
 	failOnError("NewMessageAuthenticator errored", err, t)
 
 	ctx := context.WithValue(context.Background(), contextkeys.UserIDCtxKey, userID)

--- a/encryption-service/app/permissions_handler.go
+++ b/encryption-service/app/permissions_handler.go
@@ -28,7 +28,7 @@ import (
 
 // Retrieve a list of users who have access to the object specified in the request.
 func (app *App) GetPermissions(ctx context.Context, request *GetPermissionsRequest) (*GetPermissionsResponse, error) {
-	_, accessObject, err := AuthorizeWrapper(ctx, app.MessageAuthenticator, request.ObjectId)
+	_, accessObject, err := AuthorizeWrapper(ctx, app.AccessObjectMAC, request.ObjectId)
 	if err != nil {
 		// AuthorizeWrapper logs and generates user facing error, just pass it on here
 		return nil, err
@@ -65,7 +65,7 @@ func (app *App) AddPermission(ctx context.Context, request *AddPermissionRequest
 		return nil, err
 	}
 
-	authorizer, accessObject, err := AuthorizeWrapper(ctx, app.MessageAuthenticator, request.ObjectId)
+	authorizer, accessObject, err := AuthorizeWrapper(ctx, app.AccessObjectMAC, request.ObjectId)
 	if err != nil {
 		// AuthorizeWrapper logs and generates user facing error, just pass it on here
 		return nil, err
@@ -126,7 +126,7 @@ func (app *App) RemovePermission(ctx context.Context, request *RemovePermissionR
 		return nil, err
 	}
 
-	authorizer, accessObject, err := AuthorizeWrapper(ctx, app.MessageAuthenticator, request.ObjectId)
+	authorizer, accessObject, err := AuthorizeWrapper(ctx, app.AccessObjectMAC, request.ObjectId)
 	if err != nil {
 		// AuthorizeWrapper logs and generates user facing error, just pass it on here
 		return nil, err

--- a/encryption-service/app/permissions_handler_test.go
+++ b/encryption-service/app/permissions_handler_test.go
@@ -29,13 +29,13 @@ import (
 	"encryption-service/crypt"
 )
 
-var ma, _ = crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+var ma, _ = crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), crypt.AccessObjectsDomain)
 var authorizer = &authz.Authorizer{
-	MessageAuthenticator: ma,
+	AccessObjectMAC: ma,
 }
 
 var app = App{
-	MessageAuthenticator: ma,
+	AccessObjectMAC: ma,
 }
 
 var targetID = uuid.Must(uuid.NewV4())

--- a/encryption-service/app/storage_handlers.go
+++ b/encryption-service/app/storage_handlers.go
@@ -56,8 +56,8 @@ func (app *App) Store(ctx context.Context, request *StoreRequest) (*StoreRespons
 	}
 
 	authorizer := &authz.Authorizer{
-		MessageAuthenticator: app.MessageAuthenticator,
-		AuthStoreTx:          authStorageTx,
+		AccessObjectMAC: app.AccessObjectMAC,
+		AuthStoreTx:     authStorageTx,
 	}
 
 	oek, err := authorizer.CreateObject(ctx, objectID, userID, app.Config.KEK)
@@ -99,7 +99,7 @@ func (app *App) Store(ctx context.Context, request *StoreRequest) (*StoreRespons
 // Errors if authentication, authorization, or retrieving the object fails
 func (app *App) Retrieve(ctx context.Context, request *RetrieveRequest) (*RetrieveResponse, error) {
 	objectIDString := request.ObjectId
-	_, accessObject, err := AuthorizeWrapper(ctx, app.MessageAuthenticator, objectIDString)
+	_, accessObject, err := AuthorizeWrapper(ctx, app.AccessObjectMAC, objectIDString)
 	if err != nil {
 		// AuthorizeWrapper logs and generates user facing error, just pass it on here
 		return nil, err

--- a/encryption-service/app/storage_handlers_test.go
+++ b/encryption-service/app/storage_handlers_test.go
@@ -40,7 +40,7 @@ func (o *ObjectStoreMock) Retrieve(ctx context.Context, objectID string) ([]byte
 	return o.RetrieveFunc(ctx, objectID)
 }
 
-var messageAuthenticator, _ = crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+var messageAuthenticator, _ = crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), crypt.AccessObjectsDomain)
 
 var config = &Config{
 	KEK: []byte("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"),
@@ -52,10 +52,10 @@ func TestStoreRetrieve(t *testing.T) {
 	authStorageTx, _ := authStore.NewTransaction(context.TODO())
 
 	app := App{
-		ObjectStore:          objectstorage.NewMemoryObjectStore(),
-		MessageAuthenticator: messageAuthenticator,
-		Config:               config,
-		Crypter:              &crypt.AESCrypter{},
+		ObjectStore:     objectstorage.NewMemoryObjectStore(),
+		AccessObjectMAC: messageAuthenticator,
+		Config:          config,
+		Crypter:         &crypt.AESCrypter{},
 	}
 
 	object := &Object{
@@ -100,10 +100,10 @@ func TestRetrieveBeforeStore(t *testing.T) {
 	authStorageTx, _ := authStore.NewTransaction(context.TODO())
 
 	app := App{
-		ObjectStore:          objectstorage.NewMemoryObjectStore(),
-		MessageAuthenticator: messageAuthenticator,
-		Config:               config,
-		Crypter:              &crypt.AESCrypter{},
+		ObjectStore:     objectstorage.NewMemoryObjectStore(),
+		AccessObjectMAC: messageAuthenticator,
+		Config:          config,
+		Crypter:         &crypt.AESCrypter{},
 	}
 
 	userID, err := uuid.NewV4()
@@ -139,10 +139,10 @@ func TestStoreFail(t *testing.T) {
 		},
 	}
 	app := App{
-		ObjectStore:          objectStore,
-		MessageAuthenticator: messageAuthenticator,
-		Config:               config,
-		Crypter:              &crypt.AESCrypter{},
+		ObjectStore:     objectStore,
+		AccessObjectMAC: messageAuthenticator,
+		Config:          config,
+		Crypter:         &crypt.AESCrypter{},
 	}
 
 	object := &Object{
@@ -178,10 +178,10 @@ func TestStoreFailAuth(t *testing.T) {
 		},
 	}
 	app := App{
-		ObjectStore:          objectstorage.NewMemoryObjectStore(),
-		MessageAuthenticator: messageAuthenticator,
-		Config:               config,
-		Crypter:              &crypt.AESCrypter{},
+		ObjectStore:     objectstorage.NewMemoryObjectStore(),
+		AccessObjectMAC: messageAuthenticator,
+		Config:          config,
+		Crypter:         &crypt.AESCrypter{},
 	}
 
 	object := &Object{

--- a/encryption-service/authn/authn.go
+++ b/encryption-service/authn/authn.go
@@ -29,7 +29,7 @@ import (
 
 // AuthService represents a MessageAuthenticator used for signing and checking the access token
 type AuthService struct {
-	MessageAuthenticator *crypt.MessageAuthenticator
+	TokenMAC *crypt.MessageAuthenticator
 	UnimplementedEncryptonizeServer
 }
 

--- a/encryption-service/authn/authn_test.go
+++ b/encryption-service/authn/authn_test.go
@@ -42,7 +42,7 @@ func failOnSuccess(message string, err error, t *testing.T) {
 
 func CreateUserForTests(m *crypt.MessageAuthenticator, userID uuid.UUID, scopes ScopeType) (string, error) {
 	authenticator := &AuthService{
-		MessageAuthenticator: m,
+		TokenMAC: m,
 	}
 
 	accessToken := &AccessToken{
@@ -66,7 +66,7 @@ func TestCheckAccessTokenGoodPath(t *testing.T) {
 	userScope := ScopeRead | ScopeCreate | ScopeIndex | ScopeObjectPermissions
 	ASK, _ := crypt.Random(32)
 
-	m, err := crypt.NewMessageAuthenticator(ASK)
+	m, err := crypt.NewMessageAuthenticator(ASK, crypt.TokenDomain)
 	failOnError("NewMessageAuthenticator errored", err, t)
 
 	token, err := CreateUserForTests(m, userID, userScope)
@@ -74,7 +74,7 @@ func TestCheckAccessTokenGoodPath(t *testing.T) {
 
 	var md = metadata.Pairs("authorization", token)
 	au := &AuthService{
-		MessageAuthenticator: m,
+		TokenMAC: m,
 	}
 
 	ctx := context.WithValue(context.Background(), contextkeys.MethodNameCtxKey, "/app.Encryptonize/Store")
@@ -88,7 +88,7 @@ func TestCheckAccessTokenNonBase64(t *testing.T) {
 	userScope := ScopeRead | ScopeCreate | ScopeIndex | ScopeObjectPermissions
 	ASK, _ := crypt.Random(32)
 
-	m, err := crypt.NewMessageAuthenticator(ASK)
+	m, err := crypt.NewMessageAuthenticator(ASK, crypt.TokenDomain)
 	failOnError("NewMessageAuthenticator errored %v", err, t)
 
 	goodToken, err := CreateUserForTests(m, userID, userScope)
@@ -97,7 +97,7 @@ func TestCheckAccessTokenNonBase64(t *testing.T) {
 	goodTokenParts := strings.Split(goodToken, ".")
 
 	au := &AuthService{
-		MessageAuthenticator: m,
+		TokenMAC: m,
 	}
 
 	// for each position of the split token
@@ -128,7 +128,7 @@ func TestCheckAccessTokenSwappedTokenParts(t *testing.T) {
 	userScope := ScopeRead | ScopeCreate | ScopeIndex | ScopeObjectPermissions
 	ASK, _ := crypt.Random(32)
 
-	m, err := crypt.NewMessageAuthenticator(ASK)
+	m, err := crypt.NewMessageAuthenticator(ASK, crypt.TokenDomain)
 	failOnError("NewMessageAuthenticator errored %v", err, t)
 
 	tokenFirst, err := CreateUserForTests(m, userIDFirst, userScope)
@@ -140,7 +140,7 @@ func TestCheckAccessTokenSwappedTokenParts(t *testing.T) {
 	secondTokenParts := strings.Split(tokenSecond, ".")
 
 	au := &AuthService{
-		MessageAuthenticator: m,
+		TokenMAC: m,
 	}
 
 	// for each position of the split token
@@ -171,7 +171,7 @@ func TestCheckAccessTokenInvalidAT(t *testing.T) {
 	userScope := ScopeRead | ScopeCreate | ScopeIndex | ScopeObjectPermissions
 	ASK, _ := crypt.Random(32)
 
-	m, err := crypt.NewMessageAuthenticator(ASK)
+	m, err := crypt.NewMessageAuthenticator(ASK, crypt.TokenDomain)
 	failOnError("NewMessageAuthenticator errored", err, t)
 
 	token, err := CreateUserForTests(m, userID, userScope)
@@ -180,7 +180,7 @@ func TestCheckAccessTokenInvalidAT(t *testing.T) {
 	token = "notBearer" + token[6:]
 	var md = metadata.Pairs("authorization", token)
 	au := &AuthService{
-		MessageAuthenticator: m,
+		TokenMAC: m,
 	}
 
 	ctx := context.WithValue(context.Background(), contextkeys.MethodNameCtxKey, "/app.Encryptonize/Store")
@@ -211,11 +211,11 @@ func TestCheckAccessTokenInvalidATformat(t *testing.T) {
 // all tests should fail
 func TestCheckAccessTokenNegativeScopes(t *testing.T) {
 	ASK, _ := crypt.Random(32)
-	m, err := crypt.NewMessageAuthenticator(ASK)
+	m, err := crypt.NewMessageAuthenticator(ASK, crypt.TokenDomain)
 	failOnError("Error creating MessageAuthenticator", err, t)
 
 	au := &AuthService{
-		MessageAuthenticator: m,
+		TokenMAC: m,
 	}
 
 	for endpoint, rscope := range methodScopeMap {

--- a/encryption-service/authn/token.go
+++ b/encryption-service/authn/token.go
@@ -113,7 +113,7 @@ func (a *AuthService) SerializeAccessToken(accessToken *AccessToken) (string, er
 	}
 
 	msg := append(nonce, data...)
-	tag, err := a.MessageAuthenticator.Tag(crypt.TokenDomain, msg)
+	tag, err := a.TokenMAC.Tag(msg)
 	if err != nil {
 		return "", err
 	}
@@ -150,7 +150,7 @@ func (a *AuthService) ParseAccessToken(token string) (*AccessToken, error) {
 	}
 
 	msg := append(nonce, data...)
-	valid, err := a.MessageAuthenticator.Verify(crypt.TokenDomain, msg, tag)
+	valid, err := a.TokenMAC.Verify(msg, tag)
 	if err != nil {
 		return nil, err
 	}

--- a/encryption-service/authn/token_test.go
+++ b/encryption-service/authn/token_test.go
@@ -34,14 +34,14 @@ var (
 		UserScopes: userScope,
 	}
 
-	messageAuthenticator, _ = crypt.NewMessageAuthenticator(ASK)
+	messageAuthenticator, _ = crypt.NewMessageAuthenticator(ASK, crypt.TokenDomain)
 	authenticator           = &AuthService{
-		MessageAuthenticator: messageAuthenticator,
+		TokenMAC: messageAuthenticator,
 	}
 
 	expectedSerialized = "ChAAAAAAAABAAIAAAAAAAAACEgEE"
 	expectedMessage, _ = base64.RawURLEncoding.DecodeString(expectedSerialized)
-	expectedTag, _     = messageAuthenticator.Tag(crypt.TokenDomain, append(nonce, expectedMessage...))
+	expectedTag, _     = messageAuthenticator.Tag(append(nonce, expectedMessage...))
 	expectedToken      = "ChAAAAAAAABAAIAAAAAAAAACEgEE.AAAAAAAAAAAAAAAAAAAAAg." + base64.RawURLEncoding.EncodeToString(expectedTag)
 )
 
@@ -110,11 +110,11 @@ func TestParseAccessToken(t *testing.T) {
 // in auth_handlers_test (TestAuthMiddlewareSwappedTokenParts)
 
 func TestVerifyModifiedASK(t *testing.T) {
-	ma, err := crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+	ma, err := crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), crypt.TokenDomain)
 	failOnError("NewMessageAuthenticator errored", err, t)
 
 	authenticator := &AuthService{
-		MessageAuthenticator: ma,
+		TokenMAC: ma,
 	}
 
 	_, err = authenticator.ParseAccessToken(expectedToken)

--- a/encryption-service/authz/authz.go
+++ b/encryption-service/authz/authz.go
@@ -26,8 +26,8 @@ import (
 
 // Authorizer encapsulates a MessageAuthenticator and a backing Auth Storage for reading and writing Access Objects
 type Authorizer struct {
-	MessageAuthenticator *crypt.MessageAuthenticator
-	AuthStoreTx          authstorage.AuthStoreTxInterface
+	AccessObjectMAC *crypt.MessageAuthenticator
+	AuthStoreTx     authstorage.AuthStoreTxInterface
 }
 
 // serializeAccessObject serializes and signs an Object ID + Access Object into data + tag
@@ -38,7 +38,7 @@ func (a *Authorizer) SerializeAccessObject(objectID uuid.UUID, accessObject *Acc
 	}
 
 	msg := append(objectID.Bytes(), data...) // TODO: move linking to MessageAuthenticator?
-	tag, err := a.MessageAuthenticator.Tag(crypt.AccessObjectsDomain, msg)
+	tag, err := a.AccessObjectMAC.Tag(msg)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -49,7 +49,7 @@ func (a *Authorizer) SerializeAccessObject(objectID uuid.UUID, accessObject *Acc
 // parseAccessObject verifies and parses an Object ID + data + tag into an Access Object
 func (a *Authorizer) ParseAccessObject(objectID uuid.UUID, data, tag []byte) (*AccessObject, error) {
 	msg := append(objectID.Bytes(), data...) // TODO: move linking to MessageAuthenticator?
-	valid, err := a.MessageAuthenticator.Verify(crypt.AccessObjectsDomain, msg, tag)
+	valid, err := a.AccessObjectMAC.Verify(msg, tag)
 	if err != nil {
 		return nil, err
 	}

--- a/encryption-service/authz/authz_test.go
+++ b/encryption-service/authz/authz_test.go
@@ -27,9 +27,9 @@ import (
 
 // TODO: accessObject comes from access_object_test.go this is not nice
 
-var messageAuthenticator, _ = crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+var messageAuthenticator, _ = crypt.NewMessageAuthenticator([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), crypt.TokenDomain)
 var authorizer = &Authorizer{
-	MessageAuthenticator: messageAuthenticator,
+	AccessObjectMAC: messageAuthenticator,
 }
 
 func TestRemoveUserNonExisting(t *testing.T) {
@@ -74,7 +74,7 @@ func TestParseBadObjectID(t *testing.T) {
 func TestParseBadSignedData(t *testing.T) {
 	userID := uuid.Must(uuid.NewV4())
 	data := []byte("parsers hate this string")
-	tag, err := authorizer.MessageAuthenticator.Tag(crypt.TokenDomain, append(userID.Bytes(), data...))
+	tag, err := authorizer.AccessObjectMAC.Tag(append(userID.Bytes(), data...))
 	if err != nil {
 		t.Fatalf("tag failed: %v", err)
 	}

--- a/encryption-service/crypt/mac.go
+++ b/encryption-service/crypt/mac.go
@@ -25,7 +25,6 @@ import (
 
 // MessageAuthenticator encapsulates a symmetric key used for tagging msgs and verifying msgs + tags
 type MessageAuthenticator struct {
-	domain    MessageAuthenticatorDomainType
 	domainKey []byte
 }
 
@@ -54,7 +53,6 @@ func NewMessageAuthenticator(ask []byte, domain MessageAuthenticatorDomainType) 
 	}
 
 	return &MessageAuthenticator{
-		domain:    domain,
 		domainKey: domainKey,
 	}, nil
 }

--- a/encryption-service/crypt/mac_test.go
+++ b/encryption-service/crypt/mac_test.go
@@ -42,7 +42,7 @@ var (
 )
 
 func TestMessageAuthenticator(t *testing.T) {
-	s, err := NewMessageAuthenticator(ASK)
+	s, err := NewMessageAuthenticator(ASK, MessageAuthenticatorDomain)
 	if err != nil {
 		t.Fatalf("NewMessageAuthenticator errored: %v", err)
 	}
@@ -52,12 +52,12 @@ func TestMessageAuthenticator(t *testing.T) {
 		t.Fatalf("Random errored: %v", err)
 	}
 
-	tag, err := s.Tag(MessageAuthenticatorDomain, msg)
+	tag, err := s.Tag(msg)
 	if err != nil {
 		t.Fatalf("Tag errored: %v", err)
 	}
 
-	ok, err := s.Verify(MessageAuthenticatorDomain, msg, tag)
+	ok, err := s.Verify(msg, tag)
 	if err != nil {
 		t.Fatalf("Verify errored: %v", err)
 	}
@@ -68,12 +68,12 @@ func TestMessageAuthenticator(t *testing.T) {
 }
 
 func TestTag(t *testing.T) {
-	s, err := NewMessageAuthenticator(ASK)
+	s, err := NewMessageAuthenticator(ASK, MessageAuthenticatorDomain)
 	if err != nil {
 		t.Fatalf("NewMessageAuthenticator errored: %v", err)
 	}
 
-	got, err := s.Tag(MessageAuthenticatorDomain, msg)
+	got, err := s.Tag(msg)
 	if err != nil {
 		t.Fatalf("Tag errored: %v", err)
 	}
@@ -84,32 +84,27 @@ func TestTag(t *testing.T) {
 }
 
 func TestInvalidASK(t *testing.T) {
-	_, err := NewMessageAuthenticator(ASK[1:])
+	_, err := NewMessageAuthenticator(ASK[1:], MessageAuthenticatorDomain)
 	if err == nil || err.Error() != "invalid ASK size" {
 		t.Error("Sign should have errored")
 	}
 }
 
 func TestInvalidDomain(t *testing.T) {
-	s, err := NewMessageAuthenticator(ASK)
-	if err != nil {
-		t.Fatalf("NewMessageAuthenticator errored: %v", err)
-	}
 	maxUint64 := ^uint64(0)
-
-	_, err = s.Tag(MessageAuthenticatorDomainType(maxUint64), msg)
+	_, err := NewMessageAuthenticator(ASK, MessageAuthenticatorDomainType(maxUint64))
 	if err == nil || err.Error() != "invalid MessageAuthenticator Domain" {
-		t.Error("Sign should have errored")
+		t.Error("NewMessageAuthenticator should have errored")
 	}
 }
 
 func TestVerify(t *testing.T) {
-	s, err := NewMessageAuthenticator(ASK)
+	s, err := NewMessageAuthenticator(ASK, MessageAuthenticatorDomain)
 	if err != nil {
 		t.Fatalf("NewMessageAuthenticator errored: %v", err)
 	}
 
-	valid, err := s.Verify(MessageAuthenticatorDomain, msg, expectedTag)
+	valid, err := s.Verify(msg, expectedTag)
 	if err != nil {
 		t.Fatalf("Verify errored: %v", err)
 	}
@@ -121,12 +116,12 @@ func TestVerify(t *testing.T) {
 
 func TestVerifyModifiedASK(t *testing.T) {
 	ASKmodified, _ := hex.DecodeString("28855c7efc8532d92567300933cc1ca2d0586f55dcc9f054fcca2f05254fbf7e")
-	s, err := NewMessageAuthenticator(ASKmodified)
+	s, err := NewMessageAuthenticator(ASKmodified, MessageAuthenticatorDomain)
 	if err != nil {
 		t.Fatalf("NewMessageAuthenticator errored: %v", err)
 	}
 
-	valid, err := s.Verify(MessageAuthenticatorDomain, msg, expectedTag)
+	valid, err := s.Verify(msg, expectedTag)
 
 	if err != nil {
 		t.Fatalf("Verify errored: %v", err)
@@ -138,12 +133,12 @@ func TestVerifyModifiedASK(t *testing.T) {
 }
 
 func TestVerifyModifiedMsg(t *testing.T) {
-	s, err := NewMessageAuthenticator(ASK)
+	s, err := NewMessageAuthenticator(ASK, MessageAuthenticatorDomain)
 	if err != nil {
 		t.Fatalf("NewMessageAuthenticator errored: %v", err)
 	}
 
-	valid, err := s.Verify(MessageAuthenticatorDomain, append(msg, 0), expectedTag)
+	valid, err := s.Verify(append(msg, 0), expectedTag)
 	if err != nil {
 		t.Fatalf("Verify errored: %v", err)
 	}
@@ -154,12 +149,12 @@ func TestVerifyModifiedMsg(t *testing.T) {
 }
 
 func TestVerifyModifiedDomain(t *testing.T) {
-	s, err := NewMessageAuthenticator(ASK)
+	s, err := NewMessageAuthenticator(ASK, TokenDomain)
 	if err != nil {
 		t.Fatalf("NewMessageAuthenticator errored: %v", err)
 	}
 
-	valid, err := s.Verify(TokenDomain, msg, expectedTag)
+	valid, err := s.Verify(msg, expectedTag)
 	if err != nil {
 		t.Fatalf("Verify errored: %v", err)
 	}
@@ -170,12 +165,12 @@ func TestVerifyModifiedDomain(t *testing.T) {
 }
 
 func TestVerifyModifiedMAC(t *testing.T) {
-	s, err := NewMessageAuthenticator(ASK)
+	s, err := NewMessageAuthenticator(ASK, MessageAuthenticatorDomain)
 	if err != nil {
 		t.Fatalf("NewMessageAuthenticator errored: %v", err)
 	}
 
-	valid, err := s.Verify(MessageAuthenticatorDomain, msg, append(expectedTag, 0))
+	valid, err := s.Verify(msg, append(expectedTag, 0))
 	if err != nil {
 		t.Fatalf("Verify errored: %v", err)
 	}

--- a/encryption-service/main.go
+++ b/encryption-service/main.go
@@ -40,7 +40,12 @@ func main() {
 	}
 	defer authStore.Close()
 
-	messageAuthenticator, err := crypt.NewMessageAuthenticator(config.ASK)
+	accessObjectMAC, err := crypt.NewMessageAuthenticator(config.ASK, crypt.AccessObjectsDomain)
+	if err != nil {
+		log.Fatal(ctx, "NewMessageAuthenticator failed", err)
+	}
+
+	tokenMAC, err := crypt.NewMessageAuthenticator(config.ASK, crypt.TokenDomain)
 	if err != nil {
 		log.Fatal(ctx, "NewMessageAuthenticator failed", err)
 	}
@@ -53,16 +58,16 @@ func main() {
 	}
 
 	authService := &authn.AuthService{
-		MessageAuthenticator: messageAuthenticator,
+		TokenMAC: tokenMAC,
 	}
 
 	app := &app.App{
-		Config:               config,
-		MessageAuthenticator: messageAuthenticator,
-		AuthStore:            authStore,
-		AuthService:          authService,
-		ObjectStore:          objectStore,
-		Crypter:              &crypt.AESCrypter{},
+		Config:          config,
+		AccessObjectMAC: accessObjectMAC,
+		AuthStore:       authStore,
+		AuthService:     authService,
+		ObjectStore:     objectStore,
+		Crypter:         &crypt.AESCrypter{},
 	}
 
 	app.StartServer()


### PR DESCRIPTION
### Description
This PR update `MessageAuthenticator` instances to be domain specific, i.e. if you want to tag stuff with different domains, you need to create different authenticators. This change makes it easier to introduce interfaces in an upcoming PR.

### Parent Issue
Related to https://github.com/cyber-crypt-com/encryptonize-premium/issues/14

### Related Pull Requests
None

### Comments for the Reviewers
Only real changes are in `encryption-service/crypt/mac.go`.

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [x] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [x] I have added/updated unit tests for functional changes.
- [x] I have added/updated integration tests for changes that affect dependent systems.
- [x] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [x] I have updated relevant workflows and deployment tools.
- [x] I have updated/added relevant documentation (readme, doc comments, etc).
- [x] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
