### PR TITLE
remove grpc health-probe dependency

### DIFF
--- a/encryption-service/README.md
+++ b/encryption-service/README.md
@@ -13,7 +13,6 @@ You will need the following tools:
 * gocovmerge - `go get github.com/wadey/gocovmerge`
 * Docker (version 19+) - [Install instructions](https://docs.docker.com/engine/install/)
 * Docker Compose (version 1.27+)- [Install instructions](https://docs.docker.com/compose/install/)
-* gRPC health probe (version 0.3.4+) - [Install instructions](https://github.com/grpc-ecosystem/grpc-health-probe)
 
 Additionally you need to add `$(go env GOPATH)/bin` to your `PATH`, i.e. by adding
 ```bash

--- a/encryption-service/scripts/coverage.sh
+++ b/encryption-service/scripts/coverage.sh
@@ -66,7 +66,7 @@ export COMMIT=$(git rev-list -1 HEAD)
 export TAG=$(git tag --points-at HEAD)
 go test -ldflags "-X 'encryption-service/app.GitCommit=$COMMIT' -X 'encryption-service/app.GitTag=$TAG'" -coverpkg=./... -coverprofile=coverage-e2e.out -v &
 
-until $(grpc-health-probe -addr=:9000); do
+until $(docker run --net=host --rm amothic/grpc-health-probe@sha256:c56a6e93c199cf35a555655de2710528e2f37e50de9f95e3dfb66534803f6155 -addr=localhost:9000); do
     echo '[*] waiting for the server to be up'
     sleep 1
 done

--- a/encryption-service/scripts/coverage.sh
+++ b/encryption-service/scripts/coverage.sh
@@ -66,7 +66,7 @@ export COMMIT=$(git rev-list -1 HEAD)
 export TAG=$(git tag --points-at HEAD)
 go test -ldflags "-X 'encryption-service/app.GitCommit=$COMMIT' -X 'encryption-service/app.GitTag=$TAG'" -coverpkg=./... -coverprofile=coverage-e2e.out -v &
 
-until $(docker run --net=host --rm amothic/grpc-health-probe@sha256:c56a6e93c199cf35a555655de2710528e2f37e50de9f95e3dfb66534803f6155 -addr=localhost:9000); do
+until $(docker run --net=host --rm amothic/grpc-health-probe@sha256:c56a6e93c199cf35a555655de2710528e2f37e50de9f95e3dfb66534803f6155 -addr=:9000); do
     echo '[*] waiting for the server to be up'
     sleep 1
 done


### PR DESCRIPTION
### Description
Replacing grpc-health-probe with a Dockerized version so users don't have to install the dependency.

### Comments for the Reviewers
- Do we have this dependency other places than the coverage file?
