### PR TITLE
Add scope requirement to createuser call in ECCS

### DIFF
--- a/applications/ECCS/app/createuser.go
+++ b/applications/ECCS/app/createuser.go
@@ -41,6 +41,10 @@ func CreateUser(userAT string, read, create, index, objectPermissions, userManag
 		scopes = append(scopes, "USERMANAGEMENT")
 	}
 
+	if len(scopes) < 1 {
+		log.Fatalf("%v: At least a single scope is required", utils.Fail("CreateUser failed"))
+	}
+
 	// Create client
 	client, err := NewClient(userAT)
 	if err != nil {

--- a/applications/ECCS/scripts/function_tests.py
+++ b/applications/ECCS/scripts/function_tests.py
@@ -106,8 +106,12 @@ if __name__ == "__main__":
 	at = init()
 	uid1, at1 = create_user(at, "-rcip")
 	print(f"[+] created first user:  UID {uid1}, AT {at1}")
-	uid2, at2 = create_user(at)
+	uid2, at2 = create_user(at, "-r")
 	print(f"[+] created second user: UID {uid2}, AT {at2}")
+	try:
+		uid3, at3 = create_user(at)
+	except subprocess.CalledProcessError:
+		print("[+] did not create a third user without scopes")
 	oid = create_object(at1, "no one has the intention to store bytes here.")
 	print(f"[+] object created:      OID {oid}")
 	subprocess.run(["./eccs", "-a", at1, "store", "-f", "README.md", "-d", "asdf"], check=True)

--- a/applications/ECCS/scripts/function_tests.py
+++ b/applications/ECCS/scripts/function_tests.py
@@ -109,7 +109,9 @@ if __name__ == "__main__":
 	uid2, at2 = create_user(at, "-r")
 	print(f"[+] created second user: UID {uid2}, AT {at2}")
 	try:
-		uid3, at3 = create_user(at)
+		uid3, at3 = create_user(at) # expecting a subprocess.CalledProcessError when calling without scope
+		print(f"[-] A user without any scope was created, but an error was expected, aborting")
+		sys.exit(1)
 	except subprocess.CalledProcessError:
 		print("[+] did not create a third user without scopes")
 	oid = create_object(at1, "no one has the intention to store bytes here.")

--- a/encryption-service/README.md
+++ b/encryption-service/README.md
@@ -44,6 +44,7 @@ make run
 ```
 This will expose the gRPC endpoints of Encryption Service on `localhost:9000`. To connect the
 service to existing storage solutions you need to set the environment variables in [`scripts/run.sh`](scripts/run.sh).
+To create and obtain an admin token, run `make create-admin`.
 
 
 ### Docker Compose
@@ -55,12 +56,8 @@ To start the Docker Compose setup, call
 make docker-up
 ```
 This will start local instances of CockroachDB and MinIO and connect a dockerized version of the
-Encryption Service to these. An admin user with the following credentials will automatically be
-created:
-```
-User ID: 00000000-0000-4000-8000-000000000002
-Access Token: 0000000000000000000000000000000000000000000000000000000000000002
-```
+Encryption Service to these. To create and obtain an admin token, run `make docker-create-admin`.
+
 The gRPC endpoints of the Encryption Service are exposed on `localhost:9000`. MinIO's web console is
 exposed on `localhost:7000` (ID `storageid` and key `storagekey`) while CockroachDB's web console is
 exposed on `localhost:7001`.


### PR DESCRIPTION
Copy of https://github.com/cyber-crypt-com/encryptonize-core/pull/144 due to commits in the relevant branch not being signed

### Description

Adds a check for ensuring that a user created through ECCS has atleast one scope that is explicitly assigned.

### Parent Issue
None

### Related Pull Requests
None

### Comments for the Reviewers
Should be straightforward

### Type(s) of Change (Split the PR if you check many)
- [x] Added user feature
- [ ] Added technical feature
- [x] Added tests
- [ ] Refactor
- [ ] Bugfix
- [x] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [x] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [x] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
