### PR TITLE
increased linting timeout to 5 minutes

### DIFF
--- a/encryption-service/scripts/lint.sh
+++ b/encryption-service/scripts/lint.sh
@@ -28,4 +28,4 @@ echo "[*] tidying up"
 go mod tidy
 
 echo "[*] running linter"
-golangci-lint run -E gosec,asciicheck,bodyclose,gocyclo,unconvert,gocognit,misspell,golint,whitespace -D unused
+golangci-lint run -E gosec,asciicheck,bodyclose,gocyclo,unconvert,gocognit,misspell,golint,whitespace -D unused --timeout 5m


### PR DESCRIPTION
### Description
Prevent linting from timing out

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [x] CI/CD workflow changes

### General Checklist
- [x] I have pulled in the latest changes from master.
- [ ] I have run `make lint`.
- [ ] I have successfully run `make docker-up; make tests`.
- [x] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.