### PR TITLE
Align logger with standard loggers

### DIFF
--- a/encryption-service/config/config.go
+++ b/encryption-service/config/config.go
@@ -143,13 +143,13 @@ func CheckInsecure(config *Config) {
 		}
 	} else {
 		if hex.EncodeToString(config.KEK) == "0000000000000000000000000000000000000000000000000000000000000000" {
-			log.Fatal(ctx, "Test KEK used outside of INSECURE testing mode", errors.New(""))
+			log.Fatal(ctx, errors.New(""), "Test KEK used outside of INSECURE testing mode")
 		}
 		if hex.EncodeToString(config.ASK) == "0000000000000000000000000000000000000000000000000000000000000001" {
-			log.Fatal(ctx, "Test ASK used outside of INSECURE testing mode", errors.New(""))
+			log.Fatal(ctx, errors.New(""), "Test ASK used outside of INSECURE testing mode")
 		}
 		if hex.EncodeToString(config.TEK) == "0000000000000000000000000000000000000000000000000000000000000002" {
-			log.Fatal(ctx, "Test TEK used outside of INSECURE testing mode", errors.New(""))
+			log.Fatal(ctx, errors.New(""), "Test TEK used outside of INSECURE testing mode")
 		}
 	}
 }

--- a/encryption-service/config/config.go
+++ b/encryption-service/config/config.go
@@ -1,3 +1,17 @@
+// Copyright 2021 CYBERCRYPT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/encryption-service/go.sum
+++ b/encryption-service/go.sum
@@ -1,4 +1,3 @@
-cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -11,7 +10,6 @@ cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO
 cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6M=
 cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bPc=
 cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKVk=
-cloud.google.com/go v0.57.0 h1:EpMNVUorLiZIELdMZbCYX/ByTFCdoYopYAGxaGVz9ms=
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOYc=
 cloud.google.com/go v0.63.0 h1:A+DfAZQ/eWca7gvu42CS6FNSDX4R8cghF+XfWLn4R6g=
@@ -69,7 +67,6 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -97,10 +94,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -114,10 +109,8 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
-github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2 h1:FlFbCRLd5Jr4iYXZufAvgWN6Ao0JrI5chLINnUXDDr0=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
@@ -201,16 +194,13 @@ github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
-github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -234,10 +224,8 @@ github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJ
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -248,9 +236,7 @@ github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxt
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
-go.opencensus.io v0.22.3 h1:8sGtKOrtQqkN1bp2AtX+misvLIlOmsEsNd+9NIcPEm8=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
-go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -267,7 +253,6 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 h1:3zb4D3T4G8jdExgVU/95+vQXfpEPiMdCaZgmGVxjNHM=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -322,9 +307,7 @@ golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200421231249-e086a090c8fd h1:QPwSajcTUrFriMF1nJ3XzgoqakqQEsnZf9LdXdi2nkI=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5 h1:WQ8q63x+f/zpC8Ac1s9wLElVoHhm32p6tudrU72n1QA=
 golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -332,7 +315,6 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -354,7 +336,6 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -376,9 +357,7 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200501052902-10377860bb8e h1:hq86ru83GdWTlfQFZGO4nZJTU4Bs2wfHl8oFHRaXsfc=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -388,7 +367,6 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -444,7 +422,6 @@ golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -459,15 +436,12 @@ google.golang.org/api v0.17.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/
 google.golang.org/api v0.18.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.19.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.20.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
-google.golang.org/api v0.22.0 h1:J1Pl9P2lnmYFSJvgs70DKELqHNh8CNWXPbud4njEE2s=
 google.golang.org/api v0.22.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.24.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
-google.golang.org/api v0.30.0 h1:yfrXXP61wVuLb0vBcG6qaOoIoqYEzOQS8jum51jkv2w=
 google.golang.org/api v0.30.0/go.mod h1:QGmEvQ87FHZNiUVJkT14jQNYJ4ZJjdRF23ZXz5138Fc=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
-google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
@@ -515,7 +489,6 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
-google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
@@ -531,7 +504,6 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
@@ -540,7 +512,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/encryption-service/impl/authn/authn.go
+++ b/encryption-service/impl/authn/authn.go
@@ -16,7 +16,6 @@ package authn
 import (
 	context "context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -73,18 +72,18 @@ func (ua *UserAuthenticator) NewAdminUser(authStore interfaces.AuthStoreInterfac
 	// Need to inject requestID manually, as these calls don't pass the usual middleware
 	requestID, err := uuid.NewV4()
 	if err != nil {
-		log.Fatal(ctx, "Could not generate uuid", err)
+		log.Fatal(ctx, err, "Could not generate uuid")
 	}
 	ctx = context.WithValue(ctx, contextkeys.RequestIDCtxKey, requestID)
 
 	authStoreTx, err := authStore.NewTransaction(ctx)
 	if err != nil {
-		log.Fatal(ctx, "Authstorage Begin failed", err)
+		log.Fatal(ctx, err, "Authstorage Begin failed")
 	}
 	defer func() {
 		err := authStoreTx.Rollback(ctx)
 		if err != nil {
-			log.Fatal(ctx, "Performing rollback", err)
+			log.Fatal(ctx, err, "Performing rollback")
 		}
 	}()
 
@@ -92,12 +91,12 @@ func (ua *UserAuthenticator) NewAdminUser(authStore interfaces.AuthStoreInterfac
 	adminScope := scopes.ScopeUserManagement
 	userID, accessToken, err := ua.NewUser(ctx, adminScope)
 	if err != nil {
-		log.Fatal(ctx, "Create user failed", err)
+		log.Fatal(ctx, err, "Create user failed")
 	}
 
 	log.Info(ctx, "Created admin user:")
-	log.Info(ctx, fmt.Sprintf("    User ID:      %v", userID))
-	log.Info(ctx, fmt.Sprintf("    Access Token: %v", accessToken))
+	log.Infof(ctx, "    User ID:      %v", userID)
+	log.Infof(ctx, "    Access Token: %v", accessToken)
 
 	return nil
 }

--- a/encryption-service/logger/logger.go
+++ b/encryption-service/logger/logger.go
@@ -78,31 +78,58 @@ func fieldsFromCtx(ctx context.Context) log.Fields {
 
 // The following functions wrap the standard logging functions
 // in order to provide structured logging for our service
-func Error(ctx context.Context, msg string, err error) {
+func Error(ctx context.Context, err error, args ...interface{}) {
 	fields := fieldsFromCtx(ctx)
 	fields["error"] = err
-	log.WithFields(fields).Error(msg)
+	log.WithFields(fields).Error(args...)
 }
 
-func Fatal(ctx context.Context, msg string, err error) {
+func Errorf(ctx context.Context, err error, format string, args ...interface{}) {
 	fields := fieldsFromCtx(ctx)
 	fields["error"] = err
-	log.WithFields(fields).Fatal(msg)
+	log.WithFields(fields).Errorf(format, args...)
 }
 
-func Warn(ctx context.Context, msg string) {
+func Fatal(ctx context.Context, err error, args ...interface{}) {
 	fields := fieldsFromCtx(ctx)
-	log.WithFields(fields).Warn(msg)
+	fields["error"] = err
+	log.WithFields(fields).Fatal(args...)
 }
 
-func Info(ctx context.Context, msg string) {
+func Fatalf(ctx context.Context, err error, format string, args ...interface{}) {
 	fields := fieldsFromCtx(ctx)
-	log.WithFields(fields).Info(msg)
+	fields["error"] = err
+	log.WithFields(fields).Fatalf(format, args...)
 }
 
-func Debug(ctx context.Context, msg string) {
+func Warn(ctx context.Context, args ...interface{}) {
 	fields := fieldsFromCtx(ctx)
-	log.WithFields(fields).Debug(msg)
+	log.WithFields(fields).Warn(args...)
+}
+
+func Warnf(ctx context.Context, format string, args ...interface{}) {
+	fields := fieldsFromCtx(ctx)
+	log.WithFields(fields).Warnf(format, args...)
+}
+
+func Info(ctx context.Context, args ...interface{}) {
+	fields := fieldsFromCtx(ctx)
+	log.WithFields(fields).Info(args...)
+}
+
+func Infof(ctx context.Context, format string, args ...interface{}) {
+	fields := fieldsFromCtx(ctx)
+	log.WithFields(fields).Infof(format, args...)
+}
+
+func Debug(ctx context.Context, args ...interface{}) {
+	fields := fieldsFromCtx(ctx)
+	log.WithFields(fields).Debug(args...)
+}
+
+func Debugf(ctx context.Context, format string, args ...interface{}) {
+	fields := fieldsFromCtx(ctx)
+	log.WithFields(fields).Debugf(format, args...)
 }
 
 // Inject full method name into unary call

--- a/encryption-service/main.go
+++ b/encryption-service/main.go
@@ -33,26 +33,26 @@ func main() {
 
 	config, err := config.ParseConfig()
 	if err != nil {
-		log.Fatal(ctx, "Config parse failed", err)
+		log.Fatal(ctx, err, "Config parse failed")
 	}
 	log.Info(ctx, "Config parsed")
 
 	// Setup authentication storage DB Pool connection
 	authStore, err := buildtags.SetupAuthStore(context.Background(), config.AuthStorageURL)
 	if err != nil {
-		log.Fatal(ctx, "Authstorage connect failed", err)
+		log.Fatal(ctx, err, "Authstorage connect failed")
 	}
 	defer authStore.Close()
 
 	accessObjectMAC, err := crypt.NewMessageAuthenticator(config.ASK, crypt.AccessObjectsDomain)
 	if err != nil {
-		log.Fatal(ctx, "NewMessageAuthenticator failed", err)
+		log.Fatal(ctx, err, "NewMessageAuthenticator failed")
 	}
 	authorizer := &authzimpl.Authorizer{AccessObjectMAC: accessObjectMAC}
 
 	tokenCryptor, err := crypt.NewAESCryptor(config.TEK)
 	if err != nil {
-		log.Fatal(ctx, "NewAESCryptor (token) failed", err)
+		log.Fatal(ctx, err, "NewAESCryptor (token) failed")
 	}
 	userAuthenticator := &authnimpl.UserAuthenticator{Cryptor: tokenCryptor}
 
@@ -60,12 +60,12 @@ func main() {
 		config.ObjectStorageURL, "objects", config.ObjectStorageID, config.ObjectStorageKey, config.ObjectStorageCert,
 	)
 	if err != nil {
-		log.Fatal(ctx, "Objectstorage connect failed", err)
+		log.Fatal(ctx, err, "Objectstorage connect failed")
 	}
 
 	dataCryptor, err := crypt.NewAESCryptor(config.KEK)
 	if err != nil {
-		log.Fatal(ctx, "NewAESCryptor (data) failed", err)
+		log.Fatal(ctx, err, "NewAESCryptor (data) failed")
 	}
 
 	encService := &enc.Enc{

--- a/encryption-service/services/app/app.go
+++ b/encryption-service/services/app/app.go
@@ -52,7 +52,7 @@ func (app *App) initgRPC(port int) (*grpc.Server, net.Listener) {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		msg := fmt.Sprintf("Failed to listen on port: %s", fmt.Sprint(port))
-		log.Fatal(context.TODO(), msg, err)
+		log.Fatal(context.TODO(), err, msg)
 	}
 
 	// make gprc_recovery log panics and return generic errors to the caller
@@ -61,7 +61,7 @@ func (app *App) initgRPC(port int) (*grpc.Server, net.Listener) {
 			stack := make([]byte, 4096)
 			runtime.Stack(stack, false)
 			msg := fmt.Sprintf("panic recoverd: \n\n%s\n", stack)
-			log.Error(ctx, msg, fmt.Errorf("panic: %v", p))
+			log.Error(ctx, fmt.Errorf("panic: %v", p), msg)
 			return status.Errorf(codes.Internal, "internal error")
 		},
 	)
@@ -125,11 +125,11 @@ func (app *App) StartServer() {
 			msg := fmt.Sprintf("AuthenticatorInterface is of dynamic type: %v", reflect.TypeOf(app.AuthnService))
 			log.Info(ctx, msg)
 			if err := app.AuthnService.UserAuthenticator.NewAdminUser(app.AuthnService.AuthStore); err != nil {
-				log.Fatal(ctx, "CreateAdminCommand", err)
+				log.Fatal(ctx, err, "CreateAdminCommand")
 			}
 		default:
 			msg := fmt.Sprintf("Invalid command: %v", cmd)
-			log.Fatal(ctx, msg, errors.New(""))
+			log.Fatal(ctx, errors.New(""), msg)
 		}
 
 		return
@@ -142,7 +142,7 @@ func (app *App) StartServer() {
 	go func() {
 		if err := grpcServer.Serve(lis); err != nil {
 			msg := fmt.Sprintf("Failed to serve gRPC server over port %d", port)
-			log.Fatal(ctx, msg, err)
+			log.Fatal(ctx, err, msg)
 		}
 	}()
 

--- a/encryption-service/services/authn/token_middleware.go
+++ b/encryption-service/services/authn/token_middleware.go
@@ -49,7 +49,7 @@ func (au *Authn) CheckAccessToken(ctx context.Context) (context.Context, error) 
 	methodName, ok := ctx.Value(contextkeys.MethodNameCtxKey).(string)
 	if !ok {
 		err := status.Errorf(codes.Internal, "AuthenticateUser: Internal error during authentication")
-		log.Error(ctx, "Could not typecast methodName to string", err)
+		log.Error(ctx, err, "Could not typecast methodName to string")
 		return nil, err
 	}
 
@@ -61,13 +61,13 @@ func (au *Authn) CheckAccessToken(ctx context.Context) (context.Context, error) 
 
 	token, err := grpc_auth.AuthFromMD(ctx, "bearer")
 	if err != nil {
-		log.Error(ctx, "AuthenticateUser: Couldn't find token in metadata", err)
+		log.Error(ctx, err, "AuthenticateUser: Couldn't find token in metadata")
 		return nil, status.Errorf(codes.InvalidArgument, "missing access token")
 	}
 
 	accessToken, err := au.UserAuthenticator.ParseAccessToken(token)
 	if err != nil {
-		log.Error(ctx, "AuthenticateUser: Unable to parse Access Token", err)
+		log.Error(ctx, err, "AuthenticateUser: Unable to parse Access Token")
 		return nil, status.Errorf(codes.InvalidArgument, "invalid access token")
 	}
 
@@ -76,13 +76,13 @@ func (au *Authn) CheckAccessToken(ctx context.Context) (context.Context, error) 
 	reqScope, ok := methodScopeMap[methodName]
 	if !ok {
 		err = status.Errorf(codes.InvalidArgument, "invalid endpoint")
-		log.Error(newCtx, "AuthenticateUser: Invalid Endpoint", err)
+		log.Error(newCtx, err, "AuthenticateUser: Invalid Endpoint")
 		return nil, err
 	}
 
 	if !accessToken.HasScopes(reqScope) {
 		err = status.Errorf(codes.PermissionDenied, "access not authorized")
-		log.Error(newCtx, "AuthenticateUser: Unauthorized access", err)
+		log.Error(newCtx, err, "AuthenticateUser: Unauthorized access")
 		return nil, err
 	}
 

--- a/encryption-service/services/authn/user_handlers.go
+++ b/encryption-service/services/authn/user_handlers.go
@@ -43,14 +43,14 @@ func (au *Authn) CreateUser(ctx context.Context, request *CreateUserRequest) (*C
 			usertype |= scopes.ScopeUserManagement
 		default:
 			msg := fmt.Sprintf("CreateUser: Invalid scope %v", us)
-			log.Error(ctx, msg, errors.New("CreateUser: Invalid scope"))
+			log.Error(ctx, errors.New("CreateUser: Invalid scope"), msg)
 			return nil, status.Errorf(codes.InvalidArgument, "invalid scope")
 		}
 	}
 
 	userID, token, err := au.UserAuthenticator.NewUser(ctx, usertype)
 	if err != nil {
-		log.Error(ctx, "CreateUser: Couldn't create new user", err)
+		log.Error(ctx, err, "CreateUser: Couldn't create new user")
 		return nil, status.Errorf(codes.Internal, "error encountered while creating user")
 	}
 

--- a/encryption-service/services/enc/authstorage_middleware.go
+++ b/encryption-service/services/enc/authstorage_middleware.go
@@ -34,7 +34,7 @@ func (enc *Enc) AuthStorageUnaryServerInterceptor() grpc.UnaryServerInterceptor 
 		methodName, ok := ctx.Value(contextkeys.MethodNameCtxKey).(string)
 		if !ok {
 			err := status.Errorf(codes.Internal, "error encountered while connecting to auth storage")
-			log.Error(ctx, "Could not typecast methodName to string", err)
+			log.Error(ctx, err, "Could not typecast methodName to string")
 			return nil, err
 		}
 
@@ -46,13 +46,13 @@ func (enc *Enc) AuthStorageUnaryServerInterceptor() grpc.UnaryServerInterceptor 
 
 		authStoreTx, err := enc.AuthStore.NewTransaction(ctx)
 		if err != nil {
-			log.Error(ctx, "NewDBAuthStore failed", err)
+			log.Error(ctx, err, "NewDBAuthStore failed")
 			return nil, status.Errorf(codes.Internal, "error encountered while connecting to auth storage")
 		}
 		defer func() {
 			err := authStoreTx.Rollback(ctx)
 			if err != nil {
-				log.Error(ctx, "Performing rollback", err)
+				log.Error(ctx, err, "Performing rollback")
 			}
 		}()
 
@@ -70,7 +70,7 @@ func (enc *Enc) AuthStorageStreamingInterceptor() grpc.StreamServerInterceptor {
 		methodName, ok := ctx.Value(contextkeys.MethodNameCtxKey).(string)
 		if !ok {
 			err := status.Errorf(codes.Internal, "error encountered while connecting to auth storage")
-			log.Error(ctx, "Could not typecast methodName to string", err)
+			log.Error(ctx, err, "Could not typecast methodName to string")
 			return err
 		}
 
@@ -82,13 +82,13 @@ func (enc *Enc) AuthStorageStreamingInterceptor() grpc.StreamServerInterceptor {
 
 		authStoreTx, err := enc.AuthStore.NewTransaction(ctx)
 		if err != nil {
-			log.Error(ctx, "NewDBAuthStore failed", err)
+			log.Error(ctx, err, "NewDBAuthStore failed")
 			return status.Errorf(codes.Internal, "error encountered while connecting to auth storage")
 		}
 		defer func() {
 			err := authStoreTx.Rollback(ctx)
 			if err != nil {
-				log.Error(ctx, "Performing rollback", err)
+				log.Error(ctx, err, "Performing rollback")
 			}
 		}()
 

--- a/encryption-service/services/enc/authz_handlers.go
+++ b/encryption-service/services/enc/authz_handlers.go
@@ -33,7 +33,7 @@ func AuthorizeWrapper(ctx context.Context, accessObjectAuthenticator interfaces.
 	userID, ok := ctx.Value(contextkeys.UserIDCtxKey).(uuid.UUID)
 	if !ok {
 		err := status.Errorf(codes.Internal, "AuthorizeWrapper: Internal error during authorization")
-		log.Error(ctx, "Could not typecast userID to uuid.UUID", err)
+		log.Error(ctx, err, "Could not typecast userID to uuid.UUID")
 		return nil, err
 	}
 
@@ -41,14 +41,14 @@ func AuthorizeWrapper(ctx context.Context, accessObjectAuthenticator interfaces.
 	objectID, err := uuid.FromString(objectIDString)
 	if err != nil {
 		errMsg := fmt.Sprintf("AuthorizeWrapper: Failed to parse object ID %s as UUID", objectIDString)
-		log.Error(ctx, errMsg, err)
+		log.Error(ctx, err, errMsg)
 		return nil, status.Errorf(codes.InvalidArgument, "invalid object ID")
 	}
 
 	accessObject, err := accessObjectAuthenticator.FetchAccessObject(ctx, objectID)
 	if err != nil {
 		errMsg := fmt.Sprintf("AuthorizeWrapper: Couldn't fetch AccessObject for object %v", accessObject)
-		log.Error(ctx, errMsg, err)
+		log.Error(ctx, err, errMsg)
 		return nil, status.Errorf(codes.Internal, "error encountered while authorizing user")
 	}
 

--- a/encryption-service/services/enc/permissions_handler.go
+++ b/encryption-service/services/enc/permissions_handler.go
@@ -37,7 +37,7 @@ func (enc *Enc) GetPermissions(ctx context.Context, request *GetPermissionsReque
 	// Parse objectID from request
 	oid, err := uuid.FromString(request.ObjectId)
 	if err != nil {
-		log.Error(ctx, "GetPermissions: Failed to parse object ID as UUID", err)
+		log.Error(ctx, err, "GetPermissions: Failed to parse object ID as UUID")
 		return nil, status.Errorf(codes.InvalidArgument, "invalid object ID")
 	}
 
@@ -45,7 +45,7 @@ func (enc *Enc) GetPermissions(ctx context.Context, request *GetPermissionsReque
 	uids, err := accessObject.GetUsers()
 	if err != nil {
 		msg := fmt.Sprintf("GetPermissions: Couldn't parse access object for ID %v", oid)
-		log.Error(ctx, msg, err)
+		log.Error(ctx, err, msg)
 		return nil, status.Errorf(codes.Internal, "error encountered while getting permissions")
 	}
 
@@ -66,7 +66,7 @@ func (enc *Enc) AddPermission(ctx context.Context, request *AddPermissionRequest
 	authStorageTx, ok := ctx.Value(contextkeys.AuthStorageTxCtxKey).(interfaces.AuthStoreTxInterface)
 	if !ok {
 		err := status.Errorf(codes.Internal, "error encountered while adding permissions")
-		log.Error(ctx, "AddPermission: Could not typecast authstorage to AuthStoreTxInterface", err)
+		log.Error(ctx, err, "AddPermission: Could not typecast authstorage to AuthStoreTxInterface")
 		return nil, err
 	}
 
@@ -78,13 +78,13 @@ func (enc *Enc) AddPermission(ctx context.Context, request *AddPermissionRequest
 
 	oid, err := uuid.FromString(request.ObjectId)
 	if err != nil {
-		log.Error(ctx, "AddPermission: Failed to parse object ID as UUID", err)
+		log.Error(ctx, err, "AddPermission: Failed to parse object ID as UUID")
 		return nil, status.Errorf(codes.InvalidArgument, "invalid object ID")
 	}
 
 	target, err := uuid.FromString(request.Target)
 	if err != nil {
-		log.Error(ctx, "AddPermission: Failed to parse target user ID as UUID", err)
+		log.Error(ctx, err, "AddPermission: Failed to parse target user ID as UUID")
 		return nil, status.Errorf(codes.InvalidArgument, "invalid target user ID")
 	}
 
@@ -93,14 +93,14 @@ func (enc *Enc) AddPermission(ctx context.Context, request *AddPermissionRequest
 
 	if err != nil {
 		msg := fmt.Sprintf("AddPermission: Failed to retrieve target user %v", target)
-		log.Error(ctx, msg, err)
+		log.Error(ctx, err, msg)
 
 		return nil, status.Errorf(codes.Internal, "Failed to retrieve target user")
 	}
 	if !exists {
 		msg := fmt.Sprintf("AddPermission: Failed to retrieve target user %v", target)
 		err = status.Errorf(codes.InvalidArgument, "invalid target user ID")
-		log.Error(ctx, msg, err)
+		log.Error(ctx, err, msg)
 		return nil, err
 	}
 
@@ -109,13 +109,13 @@ func (enc *Enc) AddPermission(ctx context.Context, request *AddPermissionRequest
 	err = enc.Authorizer.UpsertAccessObject(ctx, oid, accessObject)
 	if err != nil {
 		msg := fmt.Sprintf("AddPermission: Failed to add user %v to access object %v", target, oid)
-		log.Error(ctx, msg, err)
+		log.Error(ctx, err, msg)
 		return nil, status.Errorf(codes.Internal, "error encountered while adding permission")
 	}
 
 	err = authStorageTx.Commit(ctx)
 	if err != nil {
-		log.Error(ctx, "AddPermission: Failed to commit auth storage transaction", err)
+		log.Error(ctx, err, "AddPermission: Failed to commit auth storage transaction")
 		return nil, status.Errorf(codes.Internal, "error encountered while adding permission")
 	}
 
@@ -132,7 +132,7 @@ func (enc *Enc) RemovePermission(ctx context.Context, request *RemovePermissionR
 	authStorageTx, ok := ctx.Value(contextkeys.AuthStorageTxCtxKey).(interfaces.AuthStoreTxInterface)
 	if !ok {
 		err := status.Errorf(codes.Internal, "error encountered while removing permissions")
-		log.Error(ctx, "RemovePermission: Could not typecast authstorage to AuthStoreTxInterface", err)
+		log.Error(ctx, err, "RemovePermission: Could not typecast authstorage to AuthStoreTxInterface")
 		return nil, err
 	}
 
@@ -144,13 +144,13 @@ func (enc *Enc) RemovePermission(ctx context.Context, request *RemovePermissionR
 
 	oid, err := uuid.FromString(request.ObjectId)
 	if err != nil {
-		log.Error(ctx, "RemovePermission: Failed to parse object ID as UUID", err)
+		log.Error(ctx, err, "RemovePermission: Failed to parse object ID as UUID")
 		return nil, status.Errorf(codes.InvalidArgument, "invalid object ID")
 	}
 
 	target, err := uuid.FromString(request.Target)
 	if err != nil {
-		log.Error(ctx, "RemovePermission: Failed to parse target user ID as UUID", err)
+		log.Error(ctx, err, "RemovePermission: Failed to parse target user ID as UUID")
 		return nil, status.Errorf(codes.InvalidArgument, "invalid target user ID")
 	}
 
@@ -159,12 +159,12 @@ func (enc *Enc) RemovePermission(ctx context.Context, request *RemovePermissionR
 	err = enc.Authorizer.UpsertAccessObject(ctx, oid, accessObject)
 	if err != nil {
 		msg := fmt.Sprintf("RemovePermission: Failed to remove user %v from access object %v", target, oid)
-		log.Error(ctx, msg, err)
+		log.Error(ctx, err, msg)
 		return nil, status.Errorf(codes.Internal, "error encountered while removing permission")
 	}
 	err = authStorageTx.Commit(ctx)
 	if err != nil {
-		log.Error(ctx, "RemovePermission: Failed to commit auth storage transaction", err)
+		log.Error(ctx, err, "RemovePermission: Failed to commit auth storage transaction")
 		return nil, status.Errorf(codes.Internal, "error encountered while removing permission")
 	}
 


### PR DESCRIPTION
### Description
This PR refactors our logger to be more aligned with standard loggers. This is useful when we have to pass a logger to Dex.

### Parent Issue
None

### Related Pull Requests
None

### Comments for the Reviewers
Only real changes are in `encryption-service/logger/logger.go`

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [x] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
