### PR TITLE
User remove handling

### DIFF
--- a/applications/ECCS/app/client.go
+++ b/applications/ECCS/app/client.go
@@ -467,3 +467,37 @@ func (c *Client) LoginUser(uid, password string) (string, error) {
 
 	return at, nil
 }
+
+func (c *Client) RemoveUser(uid string) error {
+	mth, err := c.findMethod("authn.Encryptonize", "RemoveUser")
+	if err != nil {
+		return err
+	}
+
+	// sanitize input and outputs
+	inType := mth.GetInputType()
+	var inExp = map[string]descriptorpb.FieldDescriptorProto_Type{
+		"user_id": descriptorpb.FieldDescriptorProto_TYPE_STRING,
+	}
+	if !sanitize(inType, inExp) {
+		return errors.New("Unexpected input type of RemoveUser method")
+	}
+
+	var outExp = map[string]descriptorpb.FieldDescriptorProto_Type{}
+	if !sanitize(mth.GetOutputType(), outExp) {
+		return errors.New("Unexpected output type of RemoveUser method")
+	}
+
+	// create argument
+	msg := dynamic.NewMessage(inType)
+	msg.SetFieldByName("user_id", uid)
+
+	// invoke RPC and disregard nonexisting return values
+	stub := grpcdynamic.NewStub(c.connection)
+	_, err = stub.InvokeRpc(c.ctx, mth, msg)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/applications/ECCS/app/removeuser.go
+++ b/applications/ECCS/app/removeuser.go
@@ -31,7 +31,7 @@ func RemoveUser(userAT, uid string) error {
 		log.Fatalf("%v: %v", utils.Fail("RemoveUser failed"), err)
 	}
 
-	// Print login user credentials back to user
+	// Print removal success to user
 	log.Printf("%vUid: \"%s\"", utils.Pass("Successfully removed user!\n"), uid)
 
 	return nil

--- a/applications/ECCS/app/removeuser.go
+++ b/applications/ECCS/app/removeuser.go
@@ -1,0 +1,38 @@
+// Copyright 2020 CYBERCRYPT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"eccs/utils"
+	"log"
+)
+
+// RemoveUser creates a new client and calls RemoveUser
+func RemoveUser(userAT, uid string) error {
+	client, err := NewClient(userAT)
+	if err != nil {
+		log.Fatalf("%v: %v", utils.Fail("RemoveUser failed"), err)
+	}
+
+	err = client.RemoveUser(uid)
+	if err != nil {
+		log.Fatalf("%v: %v", utils.Fail("RemoveUser failed"), err)
+	}
+
+	// Print login user credentials back to user
+	log.Printf("%vUid: \"%s\"", utils.Pass("Successfully removed user!\n"), uid)
+
+	return nil
+}

--- a/applications/ECCS/app/removeuser.go
+++ b/applications/ECCS/app/removeuser.go
@@ -1,4 +1,4 @@
-// Copyright 2020 CYBERCRYPT
+// Copyright 2021 CYBERCRYPT
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/applications/ECCS/cmd/root.go
+++ b/applications/ECCS/cmd/root.go
@@ -143,6 +143,18 @@ var loginUserCmd = &cobra.Command{
 	},
 }
 
+var removeUserCmd = &cobra.Command{
+	Use:   "removeuser",
+	Short: "Removes a user from the serivce",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := app.RemoveUser(userAT, uid)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
 func InitCmd() error {
 	// Add commands to root
 	rootCmd.AddCommand(storeCmd)
@@ -152,6 +164,7 @@ func InitCmd() error {
 	rootCmd.AddCommand(removePermissionCmd)
 	rootCmd.AddCommand(createUserCmd)
 	rootCmd.AddCommand(loginUserCmd)
+	rootCmd.AddCommand(removeUserCmd)
 
 	// Set credential flags
 	rootCmd.PersistentFlags().StringVarP(&userAT, "token", "a", "", "User access token")
@@ -206,6 +219,9 @@ func InitCmd() error {
 	// Set loginUser flags
 	loginUserCmd.Flags().StringVarP(&uid, "uid", "u", "", "UID of the user to retrieve a token for")
 	loginUserCmd.Flags().StringVarP(&password, "password", "p", "", "Password of the provided user")
+
+	// Set removeUser flags
+	removeUserCmd.Flags().StringVarP(&uid, "target", "t", "", "Target UID of the user to be removed")
 
 	return nil
 }

--- a/applications/ECCS/scripts/function_tests.py
+++ b/applications/ECCS/scripts/function_tests.py
@@ -142,7 +142,5 @@ if __name__ == "__main__":
 	subprocess.run(["./eccs", "-a", at1, "addpermission", "-o", oid, "-t", uid2], check=True)
 	subprocess.run(["./eccs", "-a", at1, "getpermissions", "-o", oid], check=True)
 	subprocess.run(["./eccs", "-a", at1, "removepermission", "-o", oid, "-t", uid2], check=True)
-
 	subprocess.run(["./eccs", "-a", at, "removeuser", "-t", uid2], check=True)
-
 	print("[+] all tests succeeded")

--- a/applications/ECCS/scripts/function_tests.py
+++ b/applications/ECCS/scripts/function_tests.py
@@ -34,6 +34,7 @@ import os
 import subprocess
 import sys
 import re
+import uuid
 
 # Initializes the server
 # Sets the endpoint if it is unset
@@ -141,4 +142,7 @@ if __name__ == "__main__":
 	subprocess.run(["./eccs", "-a", at1, "addpermission", "-o", oid, "-t", uid2], check=True)
 	subprocess.run(["./eccs", "-a", at1, "getpermissions", "-o", oid], check=True)
 	subprocess.run(["./eccs", "-a", at1, "removepermission", "-o", oid, "-t", uid2], check=True)
+
+	subprocess.run(["./eccs", "-a", at, "removeuser", "-t", uid2], check=True)
+
 	print("[+] all tests succeeded")

--- a/encryption-service/data/auth_storage_basic.sql
+++ b/encryption-service/data/auth_storage_basic.sql
@@ -2,8 +2,8 @@
 
 CREATE TABLE IF NOT EXISTS users  (
     id UUID PRIMARY KEY,
-    data BYTEA,
-    key BYTEA,
+    data BYTEA NOT NULL,
+    key BYTEA NOT NULL,
     deleted_at TIMESTAMP
 );
 

--- a/encryption-service/data/auth_storage_basic.sql
+++ b/encryption-service/data/auth_storage_basic.sql
@@ -3,7 +3,8 @@
 CREATE TABLE IF NOT EXISTS users  (
     id UUID PRIMARY KEY,
     data BYTEA,
-    key BYTEA
+    key BYTEA,
+    deleted_at TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS access_objects  (

--- a/encryption-service/impl/authn/authn.go
+++ b/encryption-service/impl/authn/authn.go
@@ -137,6 +137,25 @@ func (ua *UserAuthenticator) LoginUser(ctx context.Context, userID uuid.UUID, pr
 	return token, nil
 }
 
+func (ua *UserAuthenticator) RemoveUser(ctx context.Context, userID uuid.UUID) error {
+	authStorageTx, ok := ctx.Value(contextkeys.AuthStorageTxCtxKey).(interfaces.AuthStoreTxInterface)
+	if !ok {
+		return errors.New("Could not typecast authstorage to authstorage.AuthStoreInterface")
+	}
+
+	err := authStorageTx.RemoveUser(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	err = authStorageTx.Commit(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // NewAdminUser creates a new admin users with random credentials
 // This function is intended to be used for cli operation
 func (ua *UserAuthenticator) NewAdminUser(authStore interfaces.AuthStoreInterface) error {

--- a/encryption-service/impl/authstorage/authstorage.go
+++ b/encryption-service/impl/authstorage/authstorage.go
@@ -215,7 +215,7 @@ func (storeTx *AuthStoreTx) RemoveUser(ctx context.Context, userID uuid.UUID) er
 // Gets user's confidential data
 func (storeTx *AuthStoreTx) GetUserData(ctx context.Context, userID uuid.UUID) ([]byte, []byte, error) {
 	var data, key []byte
-	row := storeTx.Tx.QueryRow(ctx, storeTx.NewQuery("SELECT data, key FROM users WHERE id = $1 AND deleted_at is null"), userID)
+	row := storeTx.Tx.QueryRow(ctx, storeTx.NewQuery("SELECT data, key FROM users WHERE id = $1 AND deleted_at IS NULL"), userID)
 	err := row.Scan(&data, &key)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil, interfaces.ErrNotFound

--- a/encryption-service/impl/authstorage/authstorage.go
+++ b/encryption-service/impl/authstorage/authstorage.go
@@ -182,7 +182,7 @@ func (storeTx *AuthStoreTx) UserExists(ctx context.Context, userID uuid.UUID) (b
 	var fetchedID []byte
 
 	// TODO: COUNT could be more appropriate
-	row := storeTx.Tx.QueryRow(ctx, storeTx.NewQuery("SELECT id FROM users WHERE id = $1"), userID)
+	row := storeTx.Tx.QueryRow(ctx, storeTx.NewQuery("SELECT id FROM users WHERE id = $1 AND deleted_at IS NULL"), userID)
 	err := row.Scan(&fetchedID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return false, nil

--- a/encryption-service/impl/authstorage/authstorage.go
+++ b/encryption-service/impl/authstorage/authstorage.go
@@ -199,10 +199,23 @@ func (storeTx *AuthStoreTx) InsertUser(ctx context.Context, user users.UserData)
 	return err
 }
 
+// RemoveUser performs a soft delete by setting a deletion date
+func (storeTx *AuthStoreTx) RemoveUser(ctx context.Context, userID uuid.UUID) error {
+	now := time.Now()
+	res, err := storeTx.Tx.Exec(ctx, storeTx.NewQuery("UPDATE users SET deleted_at = $1 WHERE id = $2"), now, userID)
+	if err != nil {
+		return err
+	}
+	if res.RowsAffected() < 1 {
+		return interfaces.ErrNotFound
+	}
+	return nil
+}
+
 // Gets user's confidential data
 func (storeTx *AuthStoreTx) GetUserData(ctx context.Context, userID uuid.UUID) ([]byte, []byte, error) {
 	var data, key []byte
-	row := storeTx.Tx.QueryRow(ctx, storeTx.NewQuery("SELECT data, key FROM users WHERE id = $1"), userID)
+	row := storeTx.Tx.QueryRow(ctx, storeTx.NewQuery("SELECT data, key FROM users WHERE id = $1 AND deleted_at is null"), userID)
 	err := row.Scan(&data, &key)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil, interfaces.ErrNotFound

--- a/encryption-service/impl/authstorage/authstorage_mock.go
+++ b/encryption-service/impl/authstorage/authstorage_mock.go
@@ -124,7 +124,7 @@ func (m *MemoryAuthStoreTx) GetUserData(ctx context.Context, userID uuid.UUID) (
 	}
 
 	if data.DeletedAt != nil {
-		return nil, nil, errors.New("User has been deleted")
+		return nil, nil, interfaces.ErrNotFound
 	}
 
 	return data.ConfidentialUserData, data.WrappedKey, nil
@@ -149,7 +149,7 @@ func (m *MemoryAuthStoreTx) RemoveUser(ctx context.Context, userID uuid.UUID) er
 	}
 
 	if userData.DeletedAt != nil {
-		return errors.New("User has been deleted")
+		return interfaces.ErrNotFound
 	}
 
 	m.Data.Store(userID, userData)

--- a/encryption-service/impl/authstorage/authstorage_mock.go
+++ b/encryption-service/impl/authstorage/authstorage_mock.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"time"
 
 	"github.com/gofrs/uuid"
 
@@ -124,6 +123,10 @@ func (m *MemoryAuthStoreTx) GetUserData(ctx context.Context, userID uuid.UUID) (
 		return nil, nil, errors.New("unable to cast to UserData")
 	}
 
+	if data.DeletedAt != nil {
+		return nil, nil, errors.New("User has been deleted")
+	}
+
 	return data.ConfidentialUserData, data.WrappedKey, nil
 }
 
@@ -145,7 +148,10 @@ func (m *MemoryAuthStoreTx) RemoveUser(ctx context.Context, userID uuid.UUID) er
 		return errors.New("unable to cast to UserData")
 	}
 
-	userData.DeletedAt = time.Now()
+	if userData.DeletedAt != nil {
+		return errors.New("User has been deleted")
+	}
+
 	m.Data.Store(userID, userData)
 	return nil
 }

--- a/encryption-service/impl/authstorage/authstorage_mock.go
+++ b/encryption-service/impl/authstorage/authstorage_mock.go
@@ -104,8 +104,17 @@ func (m *MemoryAuthStoreTx) Rollback(ctx context.Context) error {
 }
 
 func (m *MemoryAuthStoreTx) UserExists(ctx context.Context, userID uuid.UUID) (bool, error) {
-	_, ok := m.Data.Load(userID)
+	user, ok := m.Data.Load(userID)
 	if !ok {
+		return false, nil
+	}
+
+	userData, ok := user.(users.UserData)
+	if !ok {
+		return false, errors.New("unable to cast to UserData")
+	}
+
+	if userData.DeletedAt != nil {
 		return false, nil
 	}
 

--- a/encryption-service/impl/authstorage/authstorage_mock.go
+++ b/encryption-service/impl/authstorage/authstorage_mock.go
@@ -134,7 +134,7 @@ func (m *MemoryAuthStoreTx) InsertUser(ctx context.Context, user users.UserData)
 }
 
 func (m *MemoryAuthStoreTx) RemoveUser(ctx context.Context, userID uuid.UUID) error {
-	// No concurrency safety!!
+	// TODO: unsafe for concurrent usage
 	user, ok := m.Data.Load(userID)
 	if !ok {
 		return interfaces.ErrNotFound

--- a/encryption-service/impl/authstorage/authstorage_mock.go
+++ b/encryption-service/impl/authstorage/authstorage_mock.go
@@ -137,7 +137,7 @@ func (m *MemoryAuthStoreTx) RemoveUser(ctx context.Context, userID uuid.UUID) er
 	// No concurrency safety!!
 	user, ok := m.Data.Load(userID)
 	if !ok {
-		return interfaces.ErrNoUserFound
+		return interfaces.ErrNotFound
 	}
 
 	userData, ok := user.(users.UserData)

--- a/encryption-service/interfaces/interfaces.go
+++ b/encryption-service/interfaces/interfaces.go
@@ -51,6 +51,9 @@ type AuthStoreTxInterface interface {
 	// Insert a user
 	InsertUser(ctx context.Context, userData users.UserData) (err error)
 
+	// Removes a user
+	RemoveUser(ctx context.Context, userID uuid.UUID) (err error)
+
 	//  Retrieve an existing access object
 	GetAccessObject(ctx context.Context, objectID uuid.UUID) (object, tag []byte, err error)
 
@@ -101,6 +104,8 @@ type UserAuthenticatorInterface interface {
 
 	// Logs a user in with userID and password pair
 	LoginUser(ctx context.Context, userID uuid.UUID, password string) (string, error)
+
+	RemoveUser(ctx context.Context, userID uuid.UUID) (err error)
 }
 
 type AccessObjectInterface interface {

--- a/encryption-service/interfaces/interfaces.go
+++ b/encryption-service/interfaces/interfaces.go
@@ -105,6 +105,7 @@ type UserAuthenticatorInterface interface {
 	// Logs a user in with userID and password pair
 	LoginUser(ctx context.Context, userID uuid.UUID, password string) (string, error)
 
+	// Removes a user
 	RemoveUser(ctx context.Context, userID uuid.UUID) (err error)
 }
 

--- a/encryption-service/services/authn/authn.proto
+++ b/encryption-service/services/authn/authn.proto
@@ -22,7 +22,11 @@ service Encryptonize{
   // Creates a new user on the service
   rpc CreateUser (CreateUserRequest) returns (CreateUserResponse){}
 
+  // Logs in a user to the service
   rpc LoginUser (LoginUserRequest) returns (LoginUserResponse){}
+
+  // Deletes a user in the service
+  rpc RemoveUser (RemoveUserRequest) returns (RemoveUserResponse){}
 }
 
 message CreateUserRequest{
@@ -42,3 +46,9 @@ message LoginUserRequest{
 message LoginUserResponse{
   string access_token = 1;
 }
+
+message RemoveUserRequest{
+  string user_id = 1;
+}
+
+message RemoveUserResponse{}

--- a/encryption-service/services/authn/token_middleware.go
+++ b/encryption-service/services/authn/token_middleware.go
@@ -32,6 +32,7 @@ const baseAuthPath string = "/authn.Encryptonize/"
 
 var methodScopeMap = map[string]users.ScopeType{
 	baseAuthPath + "CreateUser":      users.ScopeUserManagement,
+	baseAuthPath + "RemoveUser":      users.ScopeUserManagement,
 	baseEncPath + "GetPermissions":   users.ScopeIndex,
 	baseEncPath + "AddPermission":    users.ScopeObjectPermissions,
 	baseEncPath + "RemovePermission": users.ScopeObjectPermissions,

--- a/encryption-service/services/authn/user_handlers.go
+++ b/encryption-service/services/authn/user_handlers.go
@@ -71,11 +71,11 @@ func (au *Authn) RemoveUser(ctx context.Context, request *RemoveUserRequest) (*R
 	}
 
 	err = au.UserAuthenticator.RemoveUser(ctx, target)
+	if errors.Is(err, interfaces.ErrNotFound) {
+		log.Error(ctx, err, "RemoveUser: target with given UID doesn't exist")
+		return nil, status.Errorf(codes.NotFound, "Target user not found")
+	}
 	if err != nil {
-		if errors.Is(err, interfaces.ErrNotFound) {
-			log.Error(ctx, err, "RemoveUser: target with given UID doesn't exist")
-			return nil, status.Errorf(codes.NotFound, "Target user not found")
-		}
 		log.Error(ctx, err, "RemoveUser: Couldn't remove the user")
 		return nil, status.Errorf(codes.Internal, "error encountered while removing user")
 	}

--- a/encryption-service/services/authn/user_handlers.go
+++ b/encryption-service/services/authn/user_handlers.go
@@ -62,3 +62,19 @@ func (au *Authn) LoginUser(ctx context.Context, request *LoginUserRequest) (*Log
 	}
 	return resp, nil
 }
+
+func (au *Authn) RemoveUser(ctx context.Context, request *RemoveUserRequest) (*RemoveUserResponse, error) {
+	target, err := uuid.FromString(request.UserId)
+	if err != nil {
+		return nil, err
+	}
+
+	err = au.UserAuthenticator.RemoveUser(ctx, target)
+	if err != nil {
+		log.Error(ctx, err, "RemoveUser: Couldn't remove the user")
+		return nil, status.Errorf(codes.Internal, "error encountered while removing user")
+	}
+
+	resp := &RemoveUserResponse{}
+	return resp, nil
+}

--- a/encryption-service/services/authn/user_handlers.go
+++ b/encryption-service/services/authn/user_handlers.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"encryption-service/interfaces"
 	log "encryption-service/logger"
 	"encryption-service/users"
 )
@@ -71,6 +72,10 @@ func (au *Authn) RemoveUser(ctx context.Context, request *RemoveUserRequest) (*R
 
 	err = au.UserAuthenticator.RemoveUser(ctx, target)
 	if err != nil {
+		if errors.Is(err, interfaces.ErrNotFound) {
+			log.Error(ctx, err, "RemoveUser: target with given UID doesn't exist")
+			return nil, status.Errorf(codes.NotFound, "Target user not found")
+		}
 		log.Error(ctx, err, "RemoveUser: Couldn't remove the user")
 		return nil, status.Errorf(codes.Internal, "error encountered while removing user")
 	}

--- a/encryption-service/tests/grpc_e2e_tests/client.go
+++ b/encryption-service/tests/grpc_e2e_tests/client.go
@@ -170,6 +170,18 @@ func (c *Client) LoginUser(userid string, password string) (*authn.LoginUserResp
 	return loginUserResponse, nil
 }
 
+func (c *Client) RemoveUser(target string) (*authn.RemoveUserResponse, error) {
+	removeUserRequest := &authn.RemoveUserRequest{
+		UserId: target,
+	}
+
+	removeUserResponse, err := c.authClient.RemoveUser(c.ctx, removeUserRequest)
+	if err != nil {
+		return nil, fmt.Errorf("RemoveUser failed: %v", err)
+	}
+	return removeUserResponse, nil
+}
+
 // Perform a `Version` request.
 func (c *Client) GetVersion() (*app.VersionResponse, error) {
 	versionResponse, err := c.appClient.Version(c.ctx, &app.VersionRequest{})

--- a/encryption-service/tests/grpc_e2e_tests/grpc_e2e_user_test.go
+++ b/encryption-service/tests/grpc_e2e_tests/grpc_e2e_user_test.go
@@ -151,6 +151,6 @@ func TestRemoveUser(t *testing.T) {
 
 	// Test user login again
 	loginUserResponse, err = client.LoginUser(createUserResponse.UserId, createUserResponse.Password)
-	failOnSuccess("Login user request suceeded on a deleted user", err, t)
+	failOnSuccess("Login user request succeeded on a deleted user", err, t)
 	t.Logf("%v", loginUserResponse)
 }

--- a/encryption-service/tests/grpc_e2e_tests/grpc_e2e_user_test.go
+++ b/encryption-service/tests/grpc_e2e_tests/grpc_e2e_user_test.go
@@ -30,7 +30,7 @@ func TestCreateUser(t *testing.T) {
 
 	// Test user login
 	loginUserResponse, err := client.LoginUser(createUserResponse.UserId, createUserResponse.Password)
-	failOnError("Create user request failed", err, t)
+	failOnError("Login user request failed", err, t)
 	t.Logf("%v", loginUserResponse)
 
 	// Test that users can do stuff
@@ -127,4 +127,30 @@ func TestCreateUserWrongCredsType(t *testing.T) {
 	failOnSuccess("Admin could add object permissions", err, t)
 	_, err = clientAdmin.RemovePermission(storeResponse.ObjectId, uid2)
 	failOnSuccess("Admin could add object permissions", err, t)
+}
+
+func TestRemoveUser(t *testing.T) {
+	client, err := NewClient(endpoint, adminAT, https)
+	failOnError("Could not create client", err, t)
+	defer closeClient(client, t)
+
+	// Test user creation
+	createUserResponse, err := client.CreateUser(protoUserScopes)
+	failOnError("Create user request failed", err, t)
+	t.Logf("%v", createUserResponse)
+
+	// Test user login
+	loginUserResponse, err := client.LoginUser(createUserResponse.UserId, createUserResponse.Password)
+	failOnError("Login user request failed", err, t)
+	t.Logf("%v", loginUserResponse)
+
+	// Test user removal
+	removeUserResponse, err := client.RemoveUser(createUserResponse.UserId)
+	failOnError("Remove user request failed", err, t)
+	t.Logf("%v", removeUserResponse)
+
+	// Test user login again
+	loginUserResponse, err = client.LoginUser(createUserResponse.UserId, createUserResponse.Password)
+	failOnSuccess("Login user request suceeded on a deleted user", err, t)
+	t.Logf("%v", loginUserResponse)
 }

--- a/encryption-service/tests/grpc_e2e_tests/grpc_e2e_user_test.go
+++ b/encryption-service/tests/grpc_e2e_tests/grpc_e2e_user_test.go
@@ -154,3 +154,16 @@ func TestRemoveUser(t *testing.T) {
 	failOnSuccess("Login user request succeeded on a deleted user", err, t)
 	t.Logf("%v", loginUserResponse)
 }
+
+func TestRemoveUserNonExisting(t *testing.T) {
+	nonExistingUser := "00000000-0000-0000-0000-000000000000"
+
+	client, err := NewClient(endpoint, adminAT, https)
+	failOnError("Could not create client", err, t)
+	defer closeClient(client, t)
+
+	// Test user removal
+	removeUserResponse, err := client.RemoveUser(nonExistingUser)
+	failOnSuccess("Remove user request succeeded on a non existing user", err, t)
+	t.Logf("%v", removeUserResponse)
+}

--- a/encryption-service/users/users.go
+++ b/encryption-service/users/users.go
@@ -25,7 +25,7 @@ type UserData struct {
 	UserID               uuid.UUID
 	ConfidentialUserData []byte
 	WrappedKey           []byte
-	DeletedAt            time.Time
+	DeletedAt            *time.Time
 }
 
 func (us ScopeType) IsValid() error {

--- a/encryption-service/users/users.go
+++ b/encryption-service/users/users.go
@@ -3,6 +3,7 @@ package users
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/gofrs/uuid"
 )
@@ -24,6 +25,7 @@ type UserData struct {
 	UserID               uuid.UUID
 	ConfidentialUserData []byte
 	WrappedKey           []byte
+	DeletedAt            time.Time
 }
 
 func (us ScopeType) IsValid() error {


### PR DESCRIPTION
### Description

User remove handling. Soft delete is done by setting a non-null date for the deleted_at column

### Parent Issue
Issue #62 

### Comments for the Reviewers

Interacion can be tested through ECCS or ECCS function tests. Changes can be observed inside the database.

### Type(s) of Change (Split the PR if you check many)
- [x] Added user feature
- [ ] Added technical feature
- [x] Added tests
- [ ] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [ ] I have spent some time looking over the full diff before creating this PR.

### Technical Debt

I have not created an issue, but as talked in today's (03/24) standup, it might be a good idea to consider something for a tighter control over the deleted_at column of users
