### PR TITLE
Add proper server health check to E2E client

### DIFF
--- a/encryption-service/scripts/coverage.sh
+++ b/encryption-service/scripts/coverage.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 # Run all unit tests and end-to-end tests, generating a merged test coverage report. Usage:
-#   ./tests/run-all-tests.sh
+#   ./tests/coverage.sh
 
 
 source ./scripts/build-env
@@ -37,11 +37,7 @@ export COMMIT=$(git rev-list -1 HEAD)
 export TAG=$(git tag --points-at HEAD)
 go test -ldflags "-X 'encryption-service/services/app.GitCommit=$COMMIT' -X 'encryption-service/services/app.GitTag=$TAG'" -coverpkg=./... -coverprofile=coverage-e2e.out -v &
 
-until $(docker run --net=host --rm amothic/grpc-health-probe@sha256:c56a6e93c199cf35a555655de2710528e2f37e50de9f95e3dfb66534803f6155 -addr=:9000); do
-    echo '[*] waiting for the server to be up'
-    sleep 1
-done
-
+echo '[*] running end-to-end tests'
 go test -count=1 -v ./tests/...
 
 while pkill -f -SIGINT encryption-service.test; do

--- a/encryption-service/scripts/e2e_tests.sh
+++ b/encryption-service/scripts/e2e_tests.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Run all end-to-end tests. Requires an Encryption Server to be running. Usage:
-#   ./scripts/unit_tests.sh
+#   ./scripts/e2e_tests.sh
 #
 # By default the tests are run on a local server. To change this behaviour, the following
 # environment variables can be set:
@@ -29,11 +29,6 @@ set -euo pipefail
 
 source ./scripts/build-env
 source ./scripts/dev-env
-
-until $(docker run --net=host --rm amothic/grpc-health-probe@sha256:c56a6e93c199cf35a555655de2710528e2f37e50de9f95e3dfb66534803f6155 -addr=:9000); do
-    echo '[*] waiting for the server to be up'
-    sleep 1
-done
 
 echo '[*] running end-to-end tests'
 go test -count=1 -v ./tests/...

--- a/encryption-service/scripts/get_credentials.sh
+++ b/encryption-service/scripts/get_credentials.sh
@@ -17,7 +17,7 @@
 # Fetches certificates and credentials from encryptonize clusters. Supposed to be used with the
 # setup described in `kubernetes/README.md`. Set the the `PROJECT` environment variable before
 # running the script. Usage:
-#     ./_scripts/get_db_certificates.sh
+#     ./_scripts/get_credentials.sh
 
 set -euo pipefail
 

--- a/encryption-service/tests/grpce2e/init_test.go
+++ b/encryption-service/tests/grpce2e/init_test.go
@@ -54,6 +54,12 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Couldn't create client: %v", err)
 	}
 	defer client.Close()
+
+	// Check if the server is alive
+	if err := client.HealthCheck(); err != nil {
+		log.Fatalf("Couldn't ping test server: %v", err)
+	}
+
 	createUserResponse, err := client.CreateUser(protoUserScopes)
 	if err != nil {
 		log.Fatalf("Couldn't create test user: %v", err)


### PR DESCRIPTION
### Description
This PR replaces the "manual" `grpc-health-probe` check we did in bash before running E2E tests with a proper health check implemented on the E2E test client. 

### Parent Issue
https://github.com/orgs/cyber-crypt-com/projects/1#card-59321147

### Related Pull Requests
None

### Comments for the Reviewers
You can test this by starting the E2E tests before the server is up, e.g. run `make docker-up` and `make e2e-tests` simultaneously. The E2E tests should complete eventually. 

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [x] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
