### PR TITLE
SSH client added to github-runner

### DIFF
--- a/.github/runner-image.dockerfile
+++ b/.github/runner-image.dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Dependencies
 RUN apt-get update && \
-  apt-get install --no-install-recommends -y ca-certificates wget curl git make python3 python3-crypto python3-pycryptodome iproute2 build-essential clang && \
+  apt-get install --no-install-recommends -y ca-certificates wget curl git make python3 python3-crypto python3-pycryptodome iproute2 build-essential clang openssh-client && \
   rm -rf /var/lib/apt/lists/*
 
 # GCloud


### PR DESCRIPTION
### Description

Added SSH client so I can access GCE instances through ssh and scp, which is needed for benchmarking tests.

### Parent Issue

### Related Pull Requests

### Comments for the Reviewers

When `gcloud compute ssh` is used with our current image, an error is returned
`ERROR: (gcloud.compute.scp) Your platform does not support SSH.`

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [x] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [ ] I have pulled in the latest changes from master.
- [ ] I have run `make lint`.
- [ ] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [ ] I have spent some time looking over the full diff before creating this PR.

### Technical Debt

