### PR TITLE
Delete endpoint

### DIFF
--- a/documentation/api/api-v2.md
+++ b/documentation/api/api-v2.md
@@ -21,7 +21,8 @@ A primary change from 1.0 of the Encryptonize API is to introduce gRPC instead o
 The current service address is `app.Encryptonize`. The Encryptonize API defines the following functions:
 
 * `rpc Store (StoreRequest) returns (StoreResponse)`
-* `rpc Retrieve (RetriveRequest) returns (RetriveResponse)`
+* `rpc Retrieve (RetrieveRequest) returns (RetrieveResponse)`
+* `rpc Delete (DeleteRequest) returns (DeleteResponse){}`
 * `rpc GetPermission (GetPermissionRequest) returns (GetPermissionResponse)`
 * `rpc AddPermission (AddPermissionRequest) returns (ReturnCode)`
 * `rpc RemovePermission (RemovePermissionRequest) returns (ReturnCode)`
@@ -51,6 +52,7 @@ A user is created with a chosen set of scopes that governs the endpoints this us
 Any combination of the different scopes is valid. The scopes are:
 - `READ`
 - `CREATE`
+- `DELETE`
 - `INDEX`
 - `OBJECTPERMISSIONS`
 - `USERMANAGEMENT`
@@ -61,6 +63,7 @@ To access the endpoints the following permissions are necessary:
 |------------------|-------------------|
 | Store            | CREATE            |
 | Retrieve         | READ              |
+| Delete           | DELETE            |
 | GetPermission    | INDEC             |
 | AddPermission    | OBJECTPERMISSIONS |
 | RemovePermission | OBJECTPERMISSIONS |
@@ -130,6 +133,13 @@ the request.
 | Name             | Type             | Description           |
 |------------------|------------------|-----------------------|
 | object           | Object           | The object            |
+
+## DeleteRequest
+The structure used as an argument for a `Delete` request. It containers the Object ID of the Object the client wishes to delete.
+
+| Name      | Type   | Description           |
+|-----------|--------|-----------------------|
+| object_id | string | The object identifier |
 
 ## CreateUserRequest
 The structure used as an argument for a `CreateUser` request. It contains a list of scopes defining
@@ -209,6 +219,15 @@ the Encryption Service cannot reach the object storage. In these cases, an error
 
 ```
 rpc Retrieve (RetriveRequest) returns (RetriveResponse)
+```
+
+# Delete
+
+Deletes a previously Stored `Object`. This call does not fail if the specified object does not exist. It can fail if the caller does not have access permission to that object or if
+the Encryption Service cannot reach the object storage. In these cases, an error is returned.
+
+```
+rpc Delete (DeleteRequest) returns (DeleteResponse)
 ```
 
 # Get Permission

--- a/encryption-service/impl/authstorage/authstorage.go
+++ b/encryption-service/impl/authstorage/authstorage.go
@@ -252,3 +252,8 @@ func (storeTx *AuthStoreTx) UpdateAccessObject(ctx context.Context, objectID uui
 	_, err := storeTx.Tx.Exec(ctx, storeTx.NewQuery("UPDATE access_objects SET data = $1, tag = $2 WHERE id = $3"), data, tag, objectID)
 	return err
 }
+
+func (storeTx *AuthStoreTx) DeleteAccessObject(ctx context.Context, objectID uuid.UUID) error {
+	_, err := storeTx.Tx.Exec(ctx, storeTx.NewQuery("DELETE FROM access_objects WHERE id = $1"), objectID)
+	return err
+}

--- a/encryption-service/impl/authstorage/authstorage.go
+++ b/encryption-service/impl/authstorage/authstorage.go
@@ -254,6 +254,12 @@ func (storeTx *AuthStoreTx) UpdateAccessObject(ctx context.Context, objectID uui
 }
 
 func (storeTx *AuthStoreTx) DeleteAccessObject(ctx context.Context, objectID uuid.UUID) error {
-	_, err := storeTx.Tx.Exec(ctx, storeTx.NewQuery("DELETE FROM access_objects WHERE id = $1"), objectID)
+	row := storeTx.Tx.QueryRow(ctx, storeTx.NewQuery("SELECT 1 from access_objects WHERE id = $1"), objectID)
+	err := row.Scan()
+	// No error on OID not found during delete
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	_, err = storeTx.Tx.Exec(ctx, storeTx.NewQuery("DELETE FROM access_objects WHERE id = $1"), objectID)
 	return err
 }

--- a/encryption-service/impl/authstorage/authstorage_mock.go
+++ b/encryption-service/impl/authstorage/authstorage_mock.go
@@ -39,6 +39,7 @@ type AuthStoreTxMock struct {
 	GetAccessObjectFunc     func(ctx context.Context, objectID uuid.UUID) ([]byte, []byte, error)
 	InsertAcccessObjectFunc func(ctx context.Context, objectID uuid.UUID, data, tag []byte) error
 	UpdateAccessObjectFunc  func(ctx context.Context, objectID uuid.UUID, data, tag []byte) error
+	DeleteAccessObjectFunc  func(ctx context.Context, objectID uuid.UUID) error
 }
 
 func (db *AuthStoreTxMock) Commit(ctx context.Context) error {
@@ -73,6 +74,10 @@ func (db *AuthStoreTxMock) InsertAcccessObject(ctx context.Context, objectID uui
 
 func (db *AuthStoreTxMock) UpdateAccessObject(ctx context.Context, objectID uuid.UUID, data, tag []byte) error {
 	return db.UpdateAccessObjectFunc(ctx, objectID, data, tag)
+}
+
+func (db *AuthStoreTxMock) DeleteAccessObject(ctx context.Context, objectID uuid.UUID) error {
+	return db.DeleteAccessObjectFunc(ctx, objectID)
 }
 
 // MemoryAuthStoreTx is used by tests to mock the AutnStore in memory
@@ -193,4 +198,9 @@ func (m *MemoryAuthStoreTx) InsertAcccessObject(ctx context.Context, objectID uu
 
 func (m *MemoryAuthStoreTx) UpdateAccessObject(ctx context.Context, objectID uuid.UUID, data, tag []byte) error {
 	return m.InsertAcccessObject(ctx, objectID, data, tag)
+}
+
+func (m *MemoryAuthStoreTx) DeleteAccessObject(ctx context.Context, objectID uuid.UUID) error {
+	m.Data.Delete(objectID)
+	return nil
 }

--- a/encryption-service/impl/authz/authz.go
+++ b/encryption-service/impl/authz/authz.go
@@ -138,3 +138,12 @@ func (a *Authorizer) UpsertAccessObject(ctx context.Context, objectID uuid.UUID,
 
 	return nil
 }
+
+func (a *Authorizer) DeleteAccessObject(ctx context.Context, objectID uuid.UUID) (err error) {
+	authStorageTx, ok := ctx.Value(contextkeys.AuthStorageTxCtxKey).(interfaces.AuthStoreTxInterface)
+	if !ok {
+		return errors.New("Could not typecast authstorage to authstorage.AuthStoreInterface")
+	}
+
+	return authStorageTx.DeleteAccessObject(ctx, objectID)
+}

--- a/encryption-service/impl/authz/authz.go
+++ b/encryption-service/impl/authz/authz.go
@@ -145,5 +145,10 @@ func (a *Authorizer) DeleteAccessObject(ctx context.Context, objectID uuid.UUID)
 		return errors.New("Could not typecast authstorage to authstorage.AuthStoreInterface")
 	}
 
-	return authStorageTx.DeleteAccessObject(ctx, objectID)
+	err = authStorageTx.DeleteAccessObject(ctx, objectID)
+	if err != nil {
+		return err
+	}
+
+	return authStorageTx.Commit(ctx)
 }

--- a/encryption-service/impl/objectstorage/objectstorage.go
+++ b/encryption-service/impl/objectstorage/objectstorage.go
@@ -21,8 +21,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/gofrs/uuid"
-
 	"encryption-service/contextkeys"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -30,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/gofrs/uuid"
 )
 
 // Object store representing a connection to an S3 bucket

--- a/encryption-service/impl/objectstorage/objectstorage_mock.go
+++ b/encryption-service/impl/objectstorage/objectstorage_mock.go
@@ -49,3 +49,8 @@ func (o *MemoryObjectStore) Retrieve(ctx context.Context, objectID string) ([]by
 
 	return objectCopy, nil
 }
+
+func (o *MemoryObjectStore) Delete(ctx context.Context, objectID string) error {
+	o.Data.Delete(objectID)
+	return nil
+}

--- a/encryption-service/interfaces/interfaces.go
+++ b/encryption-service/interfaces/interfaces.go
@@ -71,6 +71,9 @@ type ObjectStoreInterface interface {
 
 	// Retrieve an object with a given object ID
 	Retrieve(ctx context.Context, objectID string) (object []byte, err error)
+
+	// Delete an object with a given object ID
+	Delete(ctx context.Context, objectID string) (err error)
 }
 
 // CryptorInterface offers an API to encrypt / decrypt data and additional associated data with a (wrapped) random key

--- a/encryption-service/interfaces/interfaces.go
+++ b/encryption-service/interfaces/interfaces.go
@@ -62,6 +62,9 @@ type AuthStoreTxInterface interface {
 
 	// Update an existing access object
 	UpdateAccessObject(ctx context.Context, objectID uuid.UUID, data, tag []byte) (err error)
+
+	// Delete an existing access object
+	DeleteAccessObject(ctx context.Context, objectID uuid.UUID) (err error)
 }
 
 // Interface representing a connection to the object store
@@ -139,6 +142,9 @@ type AccessObjectAuthenticatorInterface interface {
 
 	// Updates or inserts the AccessObject into backend storage
 	UpsertAccessObject(ctx context.Context, objectID uuid.UUID, accessObject AccessObjectInterface) (err error)
+
+	// Deletes an existing Access Object
+	DeleteAccessObject(ctx context.Context, objectID uuid.UUID) (err error)
 }
 
 // Interface for authentication of data

--- a/encryption-service/services/authn/token_middleware.go
+++ b/encryption-service/services/authn/token_middleware.go
@@ -38,6 +38,7 @@ var methodScopeMap = map[string]users.ScopeType{
 	baseEncPath + "RemovePermission": users.ScopeObjectPermissions,
 	baseEncPath + "Store":            users.ScopeCreate,
 	baseEncPath + "Retrieve":         users.ScopeRead,
+	baseEncPath + "Delete":           users.ScopeDelete,
 	baseAppPath + "Version":          users.ScopeNone,
 }
 

--- a/encryption-service/services/authn/token_middleware_test.go
+++ b/encryption-service/services/authn/token_middleware_test.go
@@ -60,7 +60,7 @@ func CreateUserForTests(c interfaces.CryptorInterface, userID uuid.UUID, scopes 
 // It ONLY tests the middleware and assumes that the LoginUser works as intended
 func TestCheckAccessTokenGoodPath(t *testing.T) {
 	userID := uuid.Must(uuid.NewV4())
-	userScope := users.ScopeRead | users.ScopeCreate | users.ScopeIndex | users.ScopeObjectPermissions
+	userScope := users.ScopeRead | users.ScopeCreate | users.ScopeDelete | users.ScopeIndex | users.ScopeObjectPermissions
 	ASK, _ := crypt.Random(32)
 	UEK, _ := crypt.Random(32)
 

--- a/encryption-service/services/authn/token_middleware_test.go
+++ b/encryption-service/services/authn/token_middleware_test.go
@@ -60,7 +60,7 @@ func CreateUserForTests(c interfaces.CryptorInterface, userID uuid.UUID, scopes 
 // It ONLY tests the middleware and assumes that the LoginUser works as intended
 func TestCheckAccessTokenGoodPath(t *testing.T) {
 	userID := uuid.Must(uuid.NewV4())
-	userScope := users.ScopeRead | users.ScopeCreate | users.ScopeDelete | users.ScopeIndex | users.ScopeObjectPermissions
+	userScope := users.ScopeRead | users.ScopeCreate | users.ScopeIndex | users.ScopeObjectPermissions
 	ASK, _ := crypt.Random(32)
 	UEK, _ := crypt.Random(32)
 

--- a/encryption-service/services/enc/authz_handlers.go
+++ b/encryption-service/services/enc/authz_handlers.go
@@ -26,6 +26,8 @@ import (
 	log "encryption-service/logger"
 )
 
+var NotFoundAccessObjectError = status.Errorf(codes.NotFound, "error encountered while authorizing user")
+
 // Wraps the Authorize call
 // Fails if uid or oid are wrongly formatted
 // or if a user isn't authorized to edit the accessObject
@@ -49,7 +51,7 @@ func AuthorizeWrapper(ctx context.Context, accessObjectAuthenticator interfaces.
 	if err != nil {
 		errMsg := fmt.Sprintf("AuthorizeWrapper: Couldn't fetch AccessObject for object %v", accessObject)
 		log.Error(ctx, err, errMsg)
-		return nil, status.Errorf(codes.Internal, "error encountered while authorizing user")
+		return nil, NotFoundAccessObjectError
 	}
 
 	authorized := accessObject.ContainsUser(userID)

--- a/encryption-service/services/enc/enc.proto
+++ b/encryption-service/services/enc/enc.proto
@@ -24,6 +24,9 @@ service Encryptonize{
   // Retrieves an object
   rpc Retrieve (RetrieveRequest) returns (RetrieveResponse){}
 
+  // Deletes an object
+  rpc Delete (DeleteRequest) returns (DeleteResponse){}
+
   // Returns list of users with permission to decrypt the Package
   rpc GetPermissions (GetPermissionsRequest) returns (GetPermissionsResponse){}
 
@@ -48,6 +51,13 @@ message RetrieveRequest{
 
 message RetrieveResponse{
   Object object = 1;
+}
+
+message DeleteRequest{
+  string object_id = 1;
+}
+
+message DeleteResponse{
 }
 
 message GetPermissionsRequest{

--- a/encryption-service/services/enc/storage_handlers.go
+++ b/encryption-service/services/enc/storage_handlers.go
@@ -127,3 +127,23 @@ func (enc *Enc) Retrieve(ctx context.Context, request *RetrieveRequest) (*Retrie
 		},
 	}, nil
 }
+
+// API exposed function, deletes a package from a storage solution
+// Assumes that user credentials are to be found in context metadata
+// Errors if authentication, authorization, or deleting the object fails
+func (enc *Enc) Delete(ctx context.Context, request *DeleteRequest) (*DeleteResponse, error) {
+	objectIDString := request.ObjectId
+	_, err := AuthorizeWrapper(ctx, enc.Authorizer, objectIDString)
+	if err != nil {
+		// AuthorizeWrapper logs and generates user facing error, just pass it on here
+		return nil, err
+	}
+
+	err = enc.ObjectStore.Delete(ctx, objectIDString)
+	if err != nil {
+		log.Error(ctx, err, "Retrieve: Failed to delete object")
+		return nil, status.Errorf(codes.Internal, "error encountered while deleting object")
+	}
+
+	return &DeleteResponse{}, nil
+}

--- a/encryption-service/services/enc/storage_handlers.go
+++ b/encryption-service/services/enc/storage_handlers.go
@@ -15,7 +15,6 @@ package enc
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gofrs/uuid"
 	"google.golang.org/grpc/codes"
@@ -143,20 +142,19 @@ func (enc *Enc) Delete(ctx context.Context, request *DeleteRequest) (*DeleteResp
 	// Parse objectID from request
 	objectID, err := uuid.FromString(objectIDString)
 	if err != nil {
-		errMsg := fmt.Sprintf("AuthorizeWrapper: Failed to parse object ID %s as UUID", objectIDString)
-		log.Error(ctx, err, errMsg)
+		log.Errorf(ctx, err, "Delete: Failed to parse object ID %s as UUID", objectIDString)
 		return nil, status.Errorf(codes.InvalidArgument, "invalid object ID")
 	}
 
 	err = enc.Authorizer.DeleteAccessObject(ctx, objectID)
 	if err != nil {
-		log.Error(ctx, err, "Retrieve: Failed to delete access object")
+		log.Error(ctx, err, "Delete: Failed to delete access object")
 		return nil, status.Errorf(codes.Internal, "error encountered while deleting access object")
 	}
 
 	err = enc.ObjectStore.Delete(ctx, objectIDString)
 	if err != nil {
-		log.Error(ctx, err, "Retrieve: Failed to delete object")
+		log.Error(ctx, err, "Delete: Failed to delete object")
 		return nil, status.Errorf(codes.Internal, "error encountered while deleting object")
 	}
 

--- a/encryption-service/services/enc/storage_handlers.go
+++ b/encryption-service/services/enc/storage_handlers.go
@@ -15,6 +15,7 @@ package enc
 
 import (
 	"context"
+	"errors"
 
 	"github.com/gofrs/uuid"
 	"google.golang.org/grpc/codes"
@@ -135,6 +136,10 @@ func (enc *Enc) Delete(ctx context.Context, request *DeleteRequest) (*DeleteResp
 	objectIDString := request.ObjectId
 	_, err := AuthorizeWrapper(ctx, enc.Authorizer, objectIDString)
 	if err != nil {
+		ok := errors.Is(err, NotFoundAccessObjectError)
+		if ok {
+			return &DeleteResponse{}, nil
+		}
 		// AuthorizeWrapper logs and generates user facing error, just pass it on here
 		return nil, err
 	}

--- a/encryption-service/services/enc/storage_handlers_test.go
+++ b/encryption-service/services/enc/storage_handlers_test.go
@@ -30,6 +30,7 @@ import (
 type ObjectStoreMock struct {
 	StoreFunc    func(ctx context.Context, objectID string, object []byte) error
 	RetrieveFunc func(ctx context.Context, objectID string) ([]byte, error)
+	DeleteFunc   func(ctx context.Context, objectID string) error
 }
 
 func (o *ObjectStoreMock) Store(ctx context.Context, objectID string, object []byte) error {
@@ -38,6 +39,10 @@ func (o *ObjectStoreMock) Store(ctx context.Context, objectID string, object []b
 
 func (o *ObjectStoreMock) Retrieve(ctx context.Context, objectID string) ([]byte, error) {
 	return o.RetrieveFunc(ctx, objectID)
+}
+
+func (o *ObjectStoreMock) Delete(ctx context.Context, objectID string) error {
+	return o.DeleteFunc(ctx, objectID)
 }
 
 var KEK = []byte("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")

--- a/encryption-service/tests/grpce2e/client.go
+++ b/encryption-service/tests/grpce2e/client.go
@@ -110,6 +110,17 @@ func (c *Client) Retrieve(oid string) (*enc.RetrieveResponse, error) {
 	return retrieveResponse, nil
 }
 
+// Perform a `Delete` request.
+func (c *Client) Delete(oid string) (*enc.DeleteResponse, error) {
+	deleteRequest := &enc.DeleteRequest{ObjectId: oid}
+
+	deleteResponse, err := c.encClient.Delete(c.ctx, deleteRequest)
+	if err != nil {
+		return nil, fmt.Errorf("Delete failed: %v", err)
+	}
+	return deleteResponse, nil
+}
+
 // Perform a `GetPermissions` request.
 func (c *Client) GetPermissions(oid string) (*enc.GetPermissionsResponse, error) {
 	getPermissionsRequest := &enc.GetPermissionsRequest{ObjectId: oid}

--- a/encryption-service/tests/grpce2e/delete_test.go
+++ b/encryption-service/tests/grpce2e/delete_test.go
@@ -31,6 +31,9 @@ func TestStoreDeleteRetrieve(t *testing.T) {
 	oid := storeResponse.ObjectId
 	_, err = client.Delete(oid)
 	failOnError("Delete operation failed", err, t)
+
+	_, err = client.Retrieve(oid)
+	failOnSuccess("Object is retrievable after delete", err, t)
 }
 
 func TestStoreDeleteTwice(t *testing.T) {

--- a/encryption-service/tests/grpce2e/delete_test.go
+++ b/encryption-service/tests/grpce2e/delete_test.go
@@ -30,5 +30,23 @@ func TestStoreDeleteRetrieve(t *testing.T) {
 	failOnError("Store operation failed", err, t)
 	oid := storeResponse.ObjectId
 	_, err = client.Delete(oid)
-	failOnError("Retrieve operation failed", err, t)
+	failOnError("Delete operation failed", err, t)
+}
+
+func TestStoreDeleteTwice(t *testing.T) {
+	client, err := NewClient(endpoint, uat, https)
+	failOnError("Could not create client", err, t)
+	defer closeClient(client, t)
+
+	plaintext := []byte("foo")
+	associatedData := []byte("bar")
+
+	storeResponse, err := client.Store(plaintext, associatedData)
+	failOnError("Store operation failed", err, t)
+	oid := storeResponse.ObjectId
+	_, err = client.Delete(oid)
+	failOnError("Delete operation failed", err, t)
+
+	_, err = client.Delete(oid)
+	failOnSuccess("Delete operation succeeded twice", err, t)
 }

--- a/encryption-service/tests/grpce2e/delete_test.go
+++ b/encryption-service/tests/grpce2e/delete_test.go
@@ -11,28 +11,24 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-syntax = "proto3";
+package grpce2e
 
-package users;
-option go_package = "encryption-service/users";
+import (
+	"testing"
+)
 
-enum UserScope{
-  READ = 0;
-  CREATE = 1;
-  INDEX = 2;
-  OBJECTPERMISSIONS = 3;
-  USERMANAGEMENT = 4;
-  DELETE = 5;
-}
+// Test the we can store an object and delete it later
+func TestStoreDeleteRetrieve(t *testing.T) {
+	client, err := NewClient(endpoint, uat, https)
+	failOnError("Could not create client", err, t)
+	defer closeClient(client, t)
 
-message AccessTokenClient{
-  bytes user_id = 1;
-  repeated users.UserScope user_scopes = 2;
-  int64 expiry_time = 3;
-}
+	plaintext := []byte("foo")
+	associatedData := []byte("bar")
 
-message ConfidentialUserData{
-  bytes hashed_password = 1;
-  bytes salt = 2;
-  repeated users.UserScope scopes = 3;
+	storeResponse, err := client.Store(plaintext, associatedData)
+	failOnError("Store operation failed", err, t)
+	oid := storeResponse.ObjectId
+	_, err = client.Delete(oid)
+	failOnError("Retrieve operation failed", err, t)
 }

--- a/encryption-service/tests/grpce2e/delete_test.go
+++ b/encryption-service/tests/grpce2e/delete_test.go
@@ -47,6 +47,7 @@ func TestStoreDeleteTwice(t *testing.T) {
 	_, err = client.Delete(oid)
 	failOnError("Delete operation failed", err, t)
 
+	// The endpoint should not return an error if the OID does not exist
 	_, err = client.Delete(oid)
-	failOnSuccess("Delete operation succeeded twice", err, t)
+	failOnError("Delete operation failed because OID doesn't exist", err, t)
 }

--- a/encryption-service/tests/grpce2e/init_test.go
+++ b/encryption-service/tests/grpce2e/init_test.go
@@ -25,7 +25,7 @@ var uid string
 var uat string
 var pwd string
 var adminAT = "wgiB4kxBTb3A0lJQNLj1Bm24g1zt-IljDda0fqoS84VfAJ_OoQsbBw.ysFgUjsYhQ_-irx0Yrf3xSeJ-CR-ZnMbq9mbBcHrPKV6g2hdBJnD0jznJJuhnLHlvJd7l20B1w"
-var protoUserScopes = []users.UserScope{users.UserScope_READ, users.UserScope_CREATE, users.UserScope_INDEX, users.UserScope_OBJECTPERMISSIONS}
+var protoUserScopes = []users.UserScope{users.UserScope_READ, users.UserScope_CREATE, users.UserScope_DELETE, users.UserScope_INDEX, users.UserScope_OBJECTPERMISSIONS}
 var protoAdminScopes = []users.UserScope{users.UserScope_USERMANAGEMENT}
 var https = false
 

--- a/encryption-service/users/users.go
+++ b/encryption-service/users/users.go
@@ -15,6 +15,7 @@ const ScopeNone ScopeType = 0
 const (
 	ScopeRead ScopeType = 1 << iota
 	ScopeCreate
+	ScopeDelete
 	ScopeIndex
 	ScopeObjectPermissions
 	ScopeUserManagement
@@ -47,6 +48,8 @@ func MapScopesToScopeType(scopes []UserScope) (ScopeType, error) {
 			userScopes |= ScopeRead
 		case UserScope_CREATE:
 			userScopes |= ScopeCreate
+		case UserScope_DELETE:
+			userScopes |= ScopeDelete
 		case UserScope_INDEX:
 			userScopes |= ScopeIndex
 		case UserScope_OBJECTPERMISSIONS:

--- a/encryption-service/users/users.go
+++ b/encryption-service/users/users.go
@@ -75,6 +75,8 @@ func MapScopetypeToScopes(scope ScopeType) ([]UserScope, error) {
 			userScope = append(userScope, UserScope_READ)
 		case ScopeCreate:
 			userScope = append(userScope, UserScope_CREATE)
+		case ScopeDelete:
+			userScope = append(userScope, UserScope_DELETE)
 		case ScopeIndex:
 			userScope = append(userScope, UserScope_INDEX)
 		case ScopeObjectPermissions:


### PR DESCRIPTION
### Description
It has been decided to use hard deletes for access objects.

If versioning is enabled on a S3 bucket, the object itself will not be deleted but a delete marker will be placed.
https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html

### Parent Issue
https://github.com/cyber-crypt-com/encryptonize-core/issues/187

### Comments for the Reviewers


### Type(s) of Change (Split the PR if you check many)
- [x] Added user feature
- [x] Added technical feature
- [x] Added tests
- [ ] Refactor
- [ ] Bugfix
- [x] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [x] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.

### Technical Debt
Concurrency issues, similar to https://github.com/cyber-crypt-com/encryptonize-core/pull/189
