### PR TITLE
Remove `storage.Object` gRPC message

### DIFF
--- a/applications/ECCS/app/store.go
+++ b/applications/ECCS/app/store.go
@@ -15,8 +15,8 @@
 package app
 
 import (
-	"log"
 	"io"
+	"log"
 	"os"
 
 	"eccs/utils"

--- a/applications/ECCS/scripts/lint.sh
+++ b/applications/ECCS/scripts/lint.sh
@@ -29,4 +29,4 @@ echo "[*] tidying up"
 go mod tidy
 
 echo "[*] running linter"
-golangci-lint run -E gosec,asciicheck,bodyclose,gocyclo,unconvert,gocognit,misspell,golint,whitespace -D unused
+golangci-lint run -E gosec,asciicheck,bodyclose,gocyclo,unconvert,gocognit,misspell,revive,whitespace -D unused --timeout 5m

--- a/documentation/docker-hub/example.sh
+++ b/documentation/docker-hub/example.sh
@@ -41,8 +41,8 @@ export ASSOCIATED_DATA=$(echo 'associated data to be stored' | base64)
 echo '[+] storing data'
 OUTPUT=$(grpcurl -plaintext \
   -H "authorization:bearer ${ACCESS_TOKEN}" \
-  -d "{\"object\": {\"plaintext\": \"${PLAINTEXT}\", \"associatedData\": \"${ASSOCIATED_DATA}\"}}" \
-  localhost:9000 enc.Encryptonize.Store)
+  -d "{\"plaintext\": \"${PLAINTEXT}\", \"associatedData\": \"${ASSOCIATED_DATA}\"}" \
+  localhost:9000 storage.Encryptonize.Store)
 echo "output: $OUTPUT"
 echo "-------------------------------------"
 export OBJECT_ID=$(jq -r '.objectId' <<< "${OUTPUT}")
@@ -53,11 +53,11 @@ echo '[+] retrieving data'
 OUTPUT=$(grpcurl -plaintext \
   -H "authorization:bearer ${ACCESS_TOKEN}" \
   -d "{\"objectId\": \"${OBJECT_ID}\"}" \
-  localhost:9000 enc.Encryptonize.Retrieve)
+  localhost:9000 storage.Encryptonize.Retrieve)
 echo "output: $OUTPUT"
 
-export RETRIEVED_PLAINTEXT=$(jq -r '.object.plaintext' <<< "${OUTPUT}")
-export RETRIEVED_ASSOCIATED_DATA=$(jq -r '.object.associatedData' <<< "${OUTPUT}")
+export RETRIEVED_PLAINTEXT=$(jq -r '.plaintext' <<< "${OUTPUT}")
+export RETRIEVED_ASSOCIATED_DATA=$(jq -r '.associatedData' <<< "${OUTPUT}")
 
 echo "plaintext: $(echo $RETRIEVED_PLAINTEXT| base64 -d)"
 echo "associated data: $(echo $RETRIEVED_ASSOCIATED_DATA| base64 -d)"

--- a/encryption-service/services/storage/storage.proto
+++ b/encryption-service/services/storage/storage.proto
@@ -41,7 +41,8 @@ service Encryptonize{
 }
 
 message StoreRequest{
-  Object object = 1;
+  bytes plaintext = 1;
+  bytes associated_data = 2;
 }
 
 message StoreResponse{
@@ -53,12 +54,14 @@ message RetrieveRequest{
 }
 
 message RetrieveResponse{
-  Object object = 1;
+  bytes plaintext = 1;
+  bytes associated_data = 2;
 }
 
 message UpdateRequest{
-  Object object = 1;
-  string object_id = 2;
+  bytes plaintext = 1;
+  bytes associated_data = 2;
+  string object_id = 3;
 }
 
 message UpdateResponse{
@@ -91,10 +94,6 @@ message RemovePermissionRequest{
   string object_id = 1;
   string target = 2;
 }
-message RemovePermissionResponse{
-}
 
-message Object{
-  bytes plaintext = 1;
-  bytes associated_data = 2;
+message RemovePermissionResponse{
 }

--- a/encryption-service/services/storage/storage_handlers.go
+++ b/encryption-service/services/storage/storage_handlers.go
@@ -56,7 +56,7 @@ func (strg *Storage) Store(ctx context.Context, request *StoreRequest) (*StoreRe
 		return nil, err
 	}
 
-	woek, ciphertext, err := strg.DataCryptor.Encrypt(request.Object.Plaintext, request.Object.AssociatedData)
+	woek, ciphertext, err := strg.DataCryptor.Encrypt(request.Plaintext, request.AssociatedData)
 	if err != nil {
 		log.Error(ctx, err, "Store: Failed to encrypt object")
 		return nil, status.Errorf(codes.Internal, "error encountered while storing object")
@@ -68,7 +68,7 @@ func (strg *Storage) Store(ctx context.Context, request *StoreRequest) (*StoreRe
 		return nil, status.Errorf(codes.Internal, "error encountered while storing object")
 	}
 
-	if err := strg.ObjectStore.Store(ctx, objectIDString+AssociatedDataStoreSuffix, request.Object.AssociatedData); err != nil {
+	if err := strg.ObjectStore.Store(ctx, objectIDString+AssociatedDataStoreSuffix, request.AssociatedData); err != nil {
 		log.Error(ctx, err, "Store: Failed to store associated data")
 		return nil, status.Errorf(codes.Internal, "error encountered while storing object")
 	}
@@ -123,10 +123,8 @@ func (strg *Storage) Retrieve(ctx context.Context, request *RetrieveRequest) (*R
 	log.Info(ctx, "Retrieve: Object retrieved")
 
 	return &RetrieveResponse{
-		Object: &Object{
-			Plaintext:      plaintext,
-			AssociatedData: aad,
-		},
+		Plaintext:      plaintext,
+		AssociatedData: aad,
 	}, nil
 }
 
@@ -179,13 +177,13 @@ func (strg *Storage) Update(ctx context.Context, request *UpdateRequest) (*Updat
 		return nil, err
 	}
 
-	ciphertext, err := strg.DataCryptor.EncryptWithKey(request.Object.Plaintext, request.Object.AssociatedData, accessObject.GetWOEK())
+	ciphertext, err := strg.DataCryptor.EncryptWithKey(request.Plaintext, request.AssociatedData, accessObject.GetWOEK())
 	if err != nil {
 		log.Error(ctx, err, "Update: Failed to encrypt object")
 		return nil, status.Errorf(codes.Internal, "error encountered while storing object")
 	}
 
-	if err := strg.ObjectStore.Store(ctx, objectIDString+AssociatedDataStoreSuffix, request.Object.AssociatedData); err != nil {
+	if err := strg.ObjectStore.Store(ctx, objectIDString+AssociatedDataStoreSuffix, request.AssociatedData); err != nil {
 		log.Error(ctx, err, "Update: Failed to store associated data")
 		return nil, status.Errorf(codes.Internal, "error encountered while storing object")
 	}

--- a/encryption-service/services/storage/storage_handlers_test.go
+++ b/encryption-service/services/storage/storage_handlers_test.go
@@ -63,11 +63,6 @@ func TestStoreRetrieve(t *testing.T) {
 		DataCryptor: dataCryptor,
 	}
 
-	object := &Object{
-		Plaintext:      []byte("plaintext_bytes"),
-		AssociatedData: []byte("associated_data_bytes"),
-	}
-
 	userID, err := uuid.NewV4()
 	if err != nil {
 		t.Fatalf("Could not create user ID: %v", err)
@@ -76,9 +71,15 @@ func TestStoreRetrieve(t *testing.T) {
 	ctx := context.WithValue(context.Background(), contextkeys.UserIDCtxKey, userID)
 	ctx = context.WithValue(ctx, contextkeys.AuthStorageTxCtxKey, authStorageTx)
 
+	plaintext := []byte("plaintext_bytes")
+	associatedData := []byte("associated_data_bytes")
+
 	storeResponse, err := strg.Store(
 		ctx,
-		&StoreRequest{Object: object},
+		&StoreRequest{
+			Plaintext:      plaintext,
+			AssociatedData: associatedData,
+		},
 	)
 	if err != nil {
 		t.Fatalf("Storing object failed: %v", err)
@@ -94,8 +95,12 @@ func TestStoreRetrieve(t *testing.T) {
 		t.Fatalf("Retrieving object failed: %v", err)
 	}
 
-	if !reflect.DeepEqual(object, retrieveResponse.Object) {
-		t.Fatalf("Retrieved object not equal to stored obect: %v != %v", retrieveResponse.Object, object)
+	if !reflect.DeepEqual(plaintext, retrieveResponse.Plaintext) {
+		t.Fatalf("Retrieved plaintext not equal to stored plaintext: %v != %v", retrieveResponse.Plaintext, plaintext)
+	}
+
+	if !reflect.DeepEqual(associatedData, retrieveResponse.AssociatedData) {
+		t.Fatalf("Retrieved associatedData not equal to stored associatedData: %v != %v", retrieveResponse.AssociatedData, associatedData)
 	}
 }
 
@@ -158,10 +163,8 @@ func TestStoreFail(t *testing.T) {
 		DataCryptor: dataCryptor,
 	}
 
-	object := &Object{
-		Plaintext:      []byte("plaintext_bytes"),
-		AssociatedData: []byte("associated_data_bytes"),
-	}
+	plaintext := []byte("plaintext_bytes")
+	associatedData := []byte("associated_data_bytes")
 
 	userID, err := uuid.NewV4()
 	if err != nil {
@@ -173,7 +176,10 @@ func TestStoreFail(t *testing.T) {
 
 	storeResponse, err := strg.Store(
 		ctx,
-		&StoreRequest{Object: object},
+		&StoreRequest{
+			Plaintext:      plaintext,
+			AssociatedData: associatedData,
+		},
 	)
 	if storeResponse != nil {
 		t.Fatalf("Expected nil storeResponse, got: %v", storeResponse)
@@ -201,10 +207,8 @@ func TestStoreFailAuth(t *testing.T) {
 		DataCryptor: dataCryptor,
 	}
 
-	object := &Object{
-		Plaintext:      []byte("plaintext_bytes"),
-		AssociatedData: []byte("associated_data_bytes"),
-	}
+	plaintext := []byte("plaintext_bytes")
+	associatedData := []byte("associated_data_bytes")
 
 	userID, err := uuid.NewV4()
 	if err != nil {
@@ -216,7 +220,10 @@ func TestStoreFailAuth(t *testing.T) {
 
 	storeResponse, err := strg.Store(
 		ctx,
-		&StoreRequest{Object: object},
+		&StoreRequest{
+			Plaintext:      plaintext,
+			AssociatedData: associatedData,
+		},
 	)
 	if storeResponse != nil {
 		t.Fatalf("Expected nil storeResponse, got: %v", storeResponse)

--- a/encryption-service/tests/grpce2e/client.go
+++ b/encryption-service/tests/grpce2e/client.go
@@ -90,10 +90,8 @@ func (c *Client) Close() error {
 // Perform a `Store` request.
 func (c *Client) Store(plaintext, associatedData []byte) (*storage.StoreResponse, error) {
 	storeRequest := &storage.StoreRequest{
-		Object: &storage.Object{
-			Plaintext:      plaintext,
-			AssociatedData: associatedData,
-		},
+		Plaintext:      plaintext,
+		AssociatedData: associatedData,
 	}
 
 	storeResponse, err := c.storageClient.Store(c.ctx, storeRequest)
@@ -116,11 +114,9 @@ func (c *Client) Retrieve(oid string) (*storage.RetrieveResponse, error) {
 
 func (c *Client) Update(oid string, plaintext, associatedData []byte) (*storage.UpdateResponse, error) {
 	updateRequest := &storage.UpdateRequest{
-		Object: &storage.Object{
-			Plaintext:      plaintext,
-			AssociatedData: associatedData,
-		},
-		ObjectId: oid,
+		Plaintext:      plaintext,
+		AssociatedData: associatedData,
+		ObjectId:       oid,
 	}
 
 	updateResponse, err := c.storageClient.Update(c.ctx, updateRequest)

--- a/encryption-service/tests/grpce2e/store_retrieve_test.go
+++ b/encryption-service/tests/grpce2e/store_retrieve_test.go
@@ -38,12 +38,12 @@ func TestStoreAndRetrieve(t *testing.T) {
 	retrieveResponse, err := client.Retrieve(oid)
 	failOnError("Retrieve operation failed", err, t)
 
-	if !bytes.Equal(retrieveResponse.Object.Plaintext, plaintext) {
-		t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse.Object.Plaintext)
+	if !bytes.Equal(retrieveResponse.Plaintext, plaintext) {
+		t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse.Plaintext)
 	}
 
-	if !bytes.Equal(retrieveResponse.Object.AssociatedData, associatedData) {
-		t.Fatalf("Expected associated data %v but got %v", associatedData, retrieveResponse.Object.AssociatedData)
+	if !bytes.Equal(retrieveResponse.AssociatedData, associatedData) {
+		t.Fatalf("Expected associated data %v but got %v", associatedData, retrieveResponse.AssociatedData)
 	}
 }
 
@@ -63,12 +63,12 @@ func TestStoreSameObjectMultipleTimes(t *testing.T) {
 		retrieveResponse, err := client.Retrieve(oid)
 		failOnError("Retrieve operation failed", err, t)
 
-		if !bytes.Equal(retrieveResponse.Object.Plaintext, plaintext) {
-			t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse.Object.Plaintext)
+		if !bytes.Equal(retrieveResponse.Plaintext, plaintext) {
+			t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse.Plaintext)
 		}
 
-		if !bytes.Equal(retrieveResponse.Object.AssociatedData, associatedData) {
-			t.Fatalf("Expected associated data %v but got %v", associatedData, retrieveResponse.Object.AssociatedData)
+		if !bytes.Equal(retrieveResponse.AssociatedData, associatedData) {
+			t.Fatalf("Expected associated data %v but got %v", associatedData, retrieveResponse.AssociatedData)
 		}
 	}
 }
@@ -102,12 +102,12 @@ func TestMultipleStoreRetrieve(t *testing.T) {
 		retrieveResponse, err := client.Retrieve(oid)
 		failOnError("Retrieve operation failed", err, t)
 
-		if !bytes.Equal(retrieveResponse.Object.Plaintext, plaintext) {
-			t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse.Object.Plaintext)
+		if !bytes.Equal(retrieveResponse.Plaintext, plaintext) {
+			t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse.Plaintext)
 		}
 
-		if !bytes.Equal(retrieveResponse.Object.AssociatedData, associatedData) {
-			t.Fatalf("Expected associated data %v but got %v", associatedData, retrieveResponse.Object.AssociatedData)
+		if !bytes.Equal(retrieveResponse.AssociatedData, associatedData) {
+			t.Fatalf("Expected associated data %v but got %v", associatedData, retrieveResponse.AssociatedData)
 		}
 	}
 }
@@ -143,12 +143,12 @@ func TestRetrieveOlderObject(t *testing.T) {
 	retrieveResponse, err := client.Retrieve(oid)
 	failOnError("Could not retrieve old object", err, t)
 
-	if !bytes.Equal(retrieveResponse.Object.Plaintext, plaintext) {
-		t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse.Object.Plaintext)
+	if !bytes.Equal(retrieveResponse.Plaintext, plaintext) {
+		t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse.Plaintext)
 	}
 
-	if !bytes.Equal(retrieveResponse.Object.AssociatedData, associatedData) {
-		t.Fatalf("Expected associated data %v but got %v", associatedData, retrieveResponse.Object.AssociatedData)
+	if !bytes.Equal(retrieveResponse.AssociatedData, associatedData) {
+		t.Fatalf("Expected associated data %v but got %v", associatedData, retrieveResponse.AssociatedData)
 	}
 }
 
@@ -295,8 +295,8 @@ func TestConcurrentStoreRetrieve(t *testing.T) {
 				globErr.append(fmt.Errorf("Couldn't retrieve object: %v", err))
 				return
 			}
-			if !bytes.Equal(retrieveResponse.Object.Plaintext, plaintext) {
-				globErr.append(fmt.Errorf("Plaintext didn't match. Expected:\n%v\n But got:\n%v", retrieveResponse.Object.Plaintext, plaintext))
+			if !bytes.Equal(retrieveResponse.Plaintext, plaintext) {
+				globErr.append(fmt.Errorf("Plaintext didn't match. Expected:\n%v\n But got:\n%v", retrieveResponse.Plaintext, plaintext))
 				return
 			}
 		}(&wg)
@@ -326,12 +326,12 @@ func TestStoreRetrieveEmptyObjects(t *testing.T) {
 	retrieveResponse, err := client.Retrieve(oid)
 	failOnError("Retrieve empty object failed", err, t)
 
-	if !bytes.Equal(retrieveResponse.Object.Plaintext, emptyPlaintext) {
-		t.Fatalf("Expected plaintext %v but got %v", emptyPlaintext, retrieveResponse.Object.Plaintext)
+	if !bytes.Equal(retrieveResponse.Plaintext, emptyPlaintext) {
+		t.Fatalf("Expected plaintext %v but got %v", emptyPlaintext, retrieveResponse.Plaintext)
 	}
 
-	if !bytes.Equal(retrieveResponse.Object.AssociatedData, emptyAssociatedData) {
-		t.Fatalf("Expected associated data %v but got %v", emptyAssociatedData, retrieveResponse.Object.AssociatedData)
+	if !bytes.Equal(retrieveResponse.AssociatedData, emptyAssociatedData) {
+		t.Fatalf("Expected associated data %v but got %v", emptyAssociatedData, retrieveResponse.AssociatedData)
 	}
 
 	// Store non-empty object and empty associated data
@@ -341,12 +341,12 @@ func TestStoreRetrieveEmptyObjects(t *testing.T) {
 	retrieveResponse, err = client.Retrieve(oid)
 	failOnError("Retrieve object failed", err, t)
 
-	if !bytes.Equal(retrieveResponse.Object.Plaintext, nonEmptyPlaintext) {
-		t.Fatalf("Expected plaintext %v but got %v", nonEmptyPlaintext, retrieveResponse.Object.Plaintext)
+	if !bytes.Equal(retrieveResponse.Plaintext, nonEmptyPlaintext) {
+		t.Fatalf("Expected plaintext %v but got %v", nonEmptyPlaintext, retrieveResponse.Plaintext)
 	}
 
-	if !bytes.Equal(retrieveResponse.Object.AssociatedData, emptyAssociatedData) {
-		t.Fatalf("Expected associated data %v but got %v", emptyAssociatedData, retrieveResponse.Object.AssociatedData)
+	if !bytes.Equal(retrieveResponse.AssociatedData, emptyAssociatedData) {
+		t.Fatalf("Expected associated data %v but got %v", emptyAssociatedData, retrieveResponse.AssociatedData)
 	}
 
 	// Store empty object and non-empty associated data
@@ -356,11 +356,11 @@ func TestStoreRetrieveEmptyObjects(t *testing.T) {
 	retrieveResponse, err = client.Retrieve(oid)
 	failOnError("Retrieve empty object failed", err, t)
 
-	if !bytes.Equal(retrieveResponse.Object.Plaintext, emptyPlaintext) {
-		t.Fatalf("Expected plaintext %v but got %v", emptyPlaintext, retrieveResponse.Object.Plaintext)
+	if !bytes.Equal(retrieveResponse.Plaintext, emptyPlaintext) {
+		t.Fatalf("Expected plaintext %v but got %v", emptyPlaintext, retrieveResponse.Plaintext)
 	}
 
-	if !bytes.Equal(retrieveResponse.Object.AssociatedData, nonEmptyAssociatedData) {
-		t.Fatalf("Expected associated data %v but got %v", nonEmptyAssociatedData, retrieveResponse.Object.AssociatedData)
+	if !bytes.Equal(retrieveResponse.AssociatedData, nonEmptyAssociatedData) {
+		t.Fatalf("Expected associated data %v but got %v", nonEmptyAssociatedData, retrieveResponse.AssociatedData)
 	}
 }

--- a/encryption-service/tests/grpce2e/update_test.go
+++ b/encryption-service/tests/grpce2e/update_test.go
@@ -40,12 +40,12 @@ func TestStoreAndUpdate(t *testing.T) {
 	retrieveResponse, err := client.Retrieve(oid)
 	failOnError("Retrieve operation failed", err, t)
 
-	if !bytes.Equal(retrieveResponse.Object.Plaintext, newplaintext) {
-		t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse.Object.Plaintext)
+	if !bytes.Equal(retrieveResponse.Plaintext, newplaintext) {
+		t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse.Plaintext)
 	}
 
-	if !bytes.Equal(retrieveResponse.Object.AssociatedData, newAssociatedData) {
-		t.Fatalf("Expected associated data %v but got %v", newAssociatedData, retrieveResponse.Object.AssociatedData)
+	if !bytes.Equal(retrieveResponse.AssociatedData, newAssociatedData) {
+		t.Fatalf("Expected associated data %v but got %v", newAssociatedData, retrieveResponse.AssociatedData)
 	}
 }
 
@@ -114,7 +114,7 @@ func TestStoreUpdateOtherUserRetrieve(t *testing.T) {
 	retrieveResponse2, err := client.Retrieve(oid)
 	failOnError("Retrieve operation failed", err, t)
 
-	if !bytes.Equal(retrieveResponse2.Object.Plaintext, plaintext2) {
-		t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse2.Object.Plaintext)
+	if !bytes.Equal(retrieveResponse2.Plaintext, plaintext2) {
+		t.Fatalf("Expected plaintext %v but got %v", plaintext, retrieveResponse2.Plaintext)
 	}
 }


### PR DESCRIPTION
### Description
This PR removes the `storage.Object` gRPC message to avoid an unnecessary layer of indirection. 

### Parent Issue
None

### Related Pull Requests
PR #200 

### Comments for the Reviewers
Please check if there are any leftover references to `storage.Object`.

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [x] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [x] I have added/updated unit tests for functional changes.
- [x] I have added/updated integration tests for changes that affect dependent systems.
- [x] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make docker-up; make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [x] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.

### Technical Debt
This needs to be fixed in premium as well. 