### PR TITLE
Remove sensitive logging from E2E tests

### DIFF
--- a/encryption-service/tests/grpce2e/permissions_test.go
+++ b/encryption-service/tests/grpce2e/permissions_test.go
@@ -46,11 +46,9 @@ func TestShareObjectWithUser(t *testing.T) {
 
 	createUserResponse, err := adminClient.CreateUser(protoUserScopes)
 	failOnError("Create user request failed", err, t)
-	t.Logf("%v", createUserResponse)
 
 	loginUserResponse, err := adminClient.LoginUser(createUserResponse.UserId, createUserResponse.Password)
 	failOnError("Create user request failed", err, t)
-	t.Logf("%v", loginUserResponse)
 
 	uid2 := createUserResponse.UserId
 	uat2 := loginUserResponse.AccessToken
@@ -91,11 +89,9 @@ func TestRetrieveWithoutPermissions(t *testing.T) {
 
 	createUserResponse, err := adminClient.CreateUser(protoUserScopes)
 	failOnError("Create user request failed", err, t)
-	t.Logf("%v", createUserResponse)
 
 	loginUserResponse, err := adminClient.LoginUser(createUserResponse.UserId, createUserResponse.Password)
 	failOnError("Login user request failed", err, t)
-	t.Logf("%v", loginUserResponse)
 
 	uat2 := loginUserResponse.AccessToken
 	failOnError("Couldn't parse UAT", err, t)
@@ -132,7 +128,6 @@ func TestPermissionTransitivity(t *testing.T) {
 
 	loginUserResponse, err := adminClient.LoginUser(createUserResponse.UserId, createUserResponse.Password)
 	failOnError("Login user request failed", err, t)
-	t.Logf("%v", loginUserResponse)
 
 	uid2 := createUserResponse.UserId
 	uat2 := loginUserResponse.AccessToken
@@ -143,7 +138,6 @@ func TestPermissionTransitivity(t *testing.T) {
 
 	loginUserResponse, err = adminClient.LoginUser(createUserResponse.UserId, createUserResponse.Password)
 	failOnError("Login user request failed", err, t)
-	t.Logf("%v", loginUserResponse)
 
 	uid3 := createUserResponse.UserId
 	uat3 := loginUserResponse.AccessToken
@@ -192,7 +186,6 @@ func TestGetPermissions(t *testing.T) {
 
 	loginUserResponse, err := adminClient.LoginUser(createUserResponse.UserId, createUserResponse.Password)
 	failOnError("Login user request failed", err, t)
-	t.Logf("%v", loginUserResponse)
 
 	uid2 := createUserResponse.UserId
 	uat2 := loginUserResponse.AccessToken
@@ -297,9 +290,8 @@ func TestAddPermissionsRemovedUser(t *testing.T) {
 	oid := storeResponse.ObjectId
 
 	// Test user removal
-	removeUserResponse, err := adminClient.RemoveUser(createUserResponse.UserId)
+	_, err = adminClient.RemoveUser(createUserResponse.UserId)
 	failOnError("Remove user request failed", err, t)
-	t.Logf("%v", removeUserResponse)
 
 	// Grant permissions to user 2
 	_, err = client.AddPermission(oid, createUserResponse.UserId)

--- a/encryption-service/tests/grpce2e/update_test.go
+++ b/encryption-service/tests/grpce2e/update_test.go
@@ -86,11 +86,9 @@ func TestStoreUpdateOtherUserRetrieve(t *testing.T) {
 
 	createUserResponse, err := adminClient.CreateUser(protoUserScopes)
 	failOnError("Create user request failed", err, t)
-	t.Logf("%v", createUserResponse)
 
 	loginUserResponse, err := adminClient.LoginUser(createUserResponse.UserId, createUserResponse.Password)
 	failOnError("Create user request failed", err, t)
-	t.Logf("%v", loginUserResponse)
 
 	uid2 := createUserResponse.UserId
 	uat2 := loginUserResponse.AccessToken

--- a/encryption-service/tests/grpce2e/user_test.go
+++ b/encryption-service/tests/grpce2e/user_test.go
@@ -26,12 +26,10 @@ func TestCreateUser(t *testing.T) {
 	// Test user creation
 	createUserResponse, err := client.CreateUser(protoUserScopes)
 	failOnError("Create user request failed", err, t)
-	t.Logf("%v", createUserResponse)
 
 	// Test user login
 	loginUserResponse, err := client.LoginUser(createUserResponse.UserId, createUserResponse.Password)
 	failOnError("Login user request failed", err, t)
-	t.Logf("%v", loginUserResponse)
 
 	// Test that users can do stuff
 	uat2 := loginUserResponse.AccessToken
@@ -96,9 +94,8 @@ func TestCreateUserWrongCredsType(t *testing.T) {
 	defer closeClient(client, t)
 
 	// Test that users can't access admin endpoints
-	createUserResponse, err := client.CreateUser(protoUserScopes)
+	_, err = client.CreateUser(protoUserScopes)
 	failOnSuccess("User could be created with wrong user type", err, t)
-	t.Logf("%v", createUserResponse)
 
 	// Test that admins can't access user endpoints
 	clientAdmin, err := NewClient(endpoint, adminAT, https)
@@ -137,22 +134,18 @@ func TestRemoveUser(t *testing.T) {
 	// Test user creation
 	createUserResponse, err := client.CreateUser(protoUserScopes)
 	failOnError("Create user request failed", err, t)
-	t.Logf("%v", createUserResponse)
 
 	// Test user login
-	loginUserResponse, err := client.LoginUser(createUserResponse.UserId, createUserResponse.Password)
+	_, err = client.LoginUser(createUserResponse.UserId, createUserResponse.Password)
 	failOnError("Login user request failed", err, t)
-	t.Logf("%v", loginUserResponse)
 
 	// Test user removal
-	removeUserResponse, err := client.RemoveUser(createUserResponse.UserId)
+	_, err = client.RemoveUser(createUserResponse.UserId)
 	failOnError("Remove user request failed", err, t)
-	t.Logf("%v", removeUserResponse)
 
 	// Test user login again
-	loginUserResponse, err = client.LoginUser(createUserResponse.UserId, createUserResponse.Password)
+	_, err = client.LoginUser(createUserResponse.UserId, createUserResponse.Password)
 	failOnSuccess("Login user request succeeded on a deleted user", err, t)
-	t.Logf("%v", loginUserResponse)
 }
 
 func TestRemoveUserNonExisting(t *testing.T) {
@@ -163,7 +156,6 @@ func TestRemoveUserNonExisting(t *testing.T) {
 	defer closeClient(client, t)
 
 	// Test user removal
-	removeUserResponse, err := client.RemoveUser(nonExistingUser)
+	_, err = client.RemoveUser(nonExistingUser)
 	failOnSuccess("Remove user request succeeded on a non existing user", err, t)
-	t.Logf("%v", removeUserResponse)
 }


### PR DESCRIPTION
### Description
Some of our E2E tests are logging user credentials. This is a problem when running against staging, as the Github actions logs will show these credentials. This is not a critical issue as the certificate for the endpoint is also needed, but it definitely has an extremely high risk of biting us later. 

### Comments for the Reviewers
Please check that I didn't miss any sensitive logs. 

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [x] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes
