### PR TITLE
Refactor the use of UUIDs in AccessObject

### DIFF
--- a/encryption-service/impl/authz/authz_test.go
+++ b/encryption-service/impl/authz/authz_test.go
@@ -34,11 +34,11 @@ var authorizer = &Authorizer{
 }
 
 func TestRemoveUserNonExisting(t *testing.T) {
-	expected := append([][]byte(nil), accessObject.UserIds...)
+	expected := accessObject.UserIDs
 
 	accessObject.RemoveUser(uuid.Must(uuid.FromString("A0000000-0000-0000-0000-000000000000")))
 
-	if !reflect.DeepEqual(expected, accessObject.UserIds) {
+	if !reflect.DeepEqual(expected, accessObject.UserIDs) {
 		t.Error("Remove User Non Existing failed")
 	}
 }
@@ -201,7 +201,7 @@ func TestUpdatePermissions(t *testing.T) {
 	objectID := uuid.Must(uuid.NewV4())
 	accessObject := &AccessObject{
 		Version: 4,
-		UserIds: [][]byte{uuid.Must(uuid.NewV4()).Bytes()},
+		UserIDs: map[uuid.UUID]bool{uuid.Must(uuid.NewV4()): true},
 		Woek:    []byte("woek"),
 	}
 

--- a/encryption-service/interfaces/interfaces.go
+++ b/encryption-service/interfaces/interfaces.go
@@ -126,7 +126,7 @@ type AccessObjectInterface interface {
 	RemoveUser(targetUserID uuid.UUID)
 
 	// GetUsers returns the list of users that may access the object
-	GetUsers() (userIDs []uuid.UUID, err error)
+	GetUsers() (userIDs map[uuid.UUID]bool)
 
 	// ContainsUser checks if the user is present in the permission list
 	ContainsUser(targetUserID uuid.UUID) (exists bool)

--- a/encryption-service/services/authz/authz_handler.go
+++ b/encryption-service/services/authz/authz_handler.go
@@ -16,6 +16,7 @@ package authz
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/gofrs/uuid"
 	"google.golang.org/grpc/codes"
@@ -43,17 +44,19 @@ func (a *Authz) GetPermissions(ctx context.Context, request *GetPermissionsReque
 	}
 
 	// Grab user ids
-	uids, err := accessObject.GetUsers()
+	uids := accessObject.GetUsers()
 	if err != nil {
 		msg := fmt.Sprintf("GetPermissions: Couldn't parse access object for ID %v", oid)
 		log.Error(ctx, err, msg)
 		return nil, status.Errorf(codes.Internal, "error encountered while getting permissions")
 	}
 
-	strUIDs := make([]string, len(uids))
-	for i, uid := range uids {
-		strUIDs[i] = uid.String()
+	strUIDs := make([]string, 0, len(uids))
+	for uid := range uids {
+		strUIDs = append(strUIDs, uid.String())
 	}
+	// Make sure order of returned list is consistent
+	sort.Strings(strUIDs)
 
 	log.Info(ctx, "GetPermissions: Permissions fetched")
 

--- a/encryption-service/services/authz/authz_handler.go
+++ b/encryption-service/services/authz/authz_handler.go
@@ -36,21 +36,8 @@ func (a *Authz) GetPermissions(ctx context.Context, request *GetPermissionsReque
 		return nil, err
 	}
 
-	// Parse objectID from request
-	oid, err := uuid.FromString(request.ObjectId)
-	if err != nil {
-		log.Error(ctx, err, "GetPermissions: Failed to parse object ID as UUID")
-		return nil, status.Errorf(codes.InvalidArgument, "invalid object ID")
-	}
-
 	// Grab user ids
 	uids := accessObject.GetUsers()
-	if err != nil {
-		msg := fmt.Sprintf("GetPermissions: Couldn't parse access object for ID %v", oid)
-		log.Error(ctx, err, msg)
-		return nil, status.Errorf(codes.Internal, "error encountered while getting permissions")
-	}
-
 	strUIDs := make([]string, 0, len(uids))
 	for uid := range uids {
 		strUIDs = append(strUIDs, uid.String())

--- a/encryption-service/services/authz/authz_handler_test.go
+++ b/encryption-service/services/authz/authz_handler_test.go
@@ -41,8 +41,8 @@ var objectID = uuid.Must(uuid.NewV4())
 var Woek, err = crypt.Random(32)
 
 var accessObject = &authzimpl.AccessObject{
-	UserIds: [][]byte{
-		userID.Bytes(),
+	UserIDs: map[uuid.UUID]bool{
+		userID: true,
 	},
 	Woek:    Woek,
 	Version: 0,

--- a/encryption-service/services/authz/authz_handler_test.go
+++ b/encryption-service/services/authz/authz_handler_test.go
@@ -78,12 +78,10 @@ func TestGetPermissions(t *testing.T) {
 	}
 }
 
-func TestGetPermissionsMissingOID(t *testing.T) {
-	ctx := context.WithValue(context.Background(), contextkeys.AccessObjectCtxKey, accessObject)
-
-	_, err = permissions.GetPermissions(ctx, &GetPermissionsRequest{})
+func TestGetPermissionsMissingAccessObject(t *testing.T) {
+	_, err = permissions.GetPermissions(context.Background(), &GetPermissionsRequest{})
 	if err == nil {
-		t.Fatalf("No object id given, should have failed")
+		t.Fatalf("No access object given, should have failed")
 	}
 }
 
@@ -128,6 +126,13 @@ func TestAddPermissionMissingOID(t *testing.T) {
 	}
 }
 
+func TestAddPermissionsMissingAccessObject(t *testing.T) {
+	_, err = permissions.AddPermission(context.Background(), &AddPermissionRequest{Target: targetID.String()})
+	if err == nil {
+		t.Fatalf("No access object given, should have failed")
+	}
+}
+
 func TestAddPermissionMissingTarget(t *testing.T) {
 	ctx := context.WithValue(context.Background(), contextkeys.AccessObjectCtxKey, accessObject)
 	ctx = context.WithValue(ctx, contextkeys.AuthStorageTxCtxKey, authnStorageTxMock)
@@ -165,5 +170,12 @@ func TestRemovePermissionMissingOID(t *testing.T) {
 	_, err = permissions.RemovePermission(ctx, &RemovePermissionRequest{Target: targetID.String()})
 	if err == nil {
 		t.Fatalf("No object id given, should have failed")
+	}
+}
+
+func TestRemovePermissionsMissingAccessObject(t *testing.T) {
+	_, err = permissions.RemovePermission(context.Background(), &RemovePermissionRequest{Target: targetID.String()})
+	if err == nil {
+		t.Fatalf("No access object given, should have failed")
 	}
 }


### PR DESCRIPTION
### Description
This PR refactors the list of user IDs in the access object from an array of serialised UUIDs to a "set" (`map[uuid.UUID]bool`] of UUIDs. This significantly simplifies the remaining logic around the access object.

### Parent Issue
Issue #227 

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [x] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### Testing Checklist
- [x] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
