### PR TITLE
Fix coverage script after bootstrap changes

### DIFF
--- a/encryption-service/scripts/coverage.sh
+++ b/encryption-service/scripts/coverage.sh
@@ -35,6 +35,7 @@ export TAG=$(git tag --points-at HEAD)
 go test -ldflags "-X 'encryption-service/services/app.GitCommit=$COMMIT' -X 'encryption-service/services/app.GitTag=$TAG'" -coverpkg=./... -coverprofile=coverage-e2e.out -v &
 
 echo '[*] running end-to-end tests'
+source <(./scripts/get-e2e-user.sh local)
 ./scripts/e2e_tests.sh
 
 while pkill -f -SIGINT encryption-service.test; do


### PR DESCRIPTION
### Description
E2E test credentials was not set in the coverage script, making it fail. 

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [x] Bugfix
- [ ] Updated documentation
- [ ] Infrastructure changes (Terraform, GCP, K8s, other)
- [ ] CI/CD workflow changes

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make tests`.
- [ ] I have updated relevant workflows and deployment tools.
- [ ] I have updated/added relevant documentation (readme, doc comments, etc).
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
