### PR TITLE
Add client with automatic token refresh

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -262,7 +262,7 @@ func (c *Client) Encrypt(plaintext, associatedData []byte) (*EncryptResponse, er
 	return response, nil
 }
 
-// Decrypt decrypts a previousy encrypted `ciphertext` and verifies the integrity of the `ciphertext`
+// Decrypt decrypts a previously encrypted `ciphertext` and verifies the integrity of the `ciphertext`
 // and `associatedData`.
 func (c *Client) Decrypt(objectID string, ciphertext, associatedData []byte) (*DecryptResponse, error) {
 	requestJSON, err := json.Marshal(request{ObjectID: objectID, Ciphertext: ciphertext, AssociatedData: associatedData})
@@ -298,7 +298,7 @@ func (c *Client) Store(plaintext, associatedData []byte) (*StoreResponse, error)
 	return response, nil
 }
 
-// Retrieve decrypts a previousy stored object returning the ciphertext.
+// Retrieve decrypts a previously stored object returning the ciphertext.
 func (c *Client) Retrieve(oid string) (*RetrieveResponse, error) {
 	requestJSON, err := json.Marshal(request{ObjectID: oid})
 	if err != nil {

--- a/client/client_refresh.go
+++ b/client/client_refresh.go
@@ -1,0 +1,275 @@
+// Copyright 2021 CYBERCRYPT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ClientWR for making gRPC calls to the Encryptonize service while automatically refreshing the
+// access token.
+type ClientWR struct { //nolint:revive
+	Client
+	uid      string
+	password string
+}
+
+// NewClientWR creates a new Encryptonize client. In order to switch credentials to another user,
+// use `LoginUser`.
+func NewClientWR(ctx context.Context, endpoint, certPath, uid, password string) (*ClientWR, error) {
+	client, err := NewClient(ctx, endpoint, certPath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = client.LoginUser(uid, password)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClientWR{
+		Client:   *client,
+		uid:      uid,
+		password: password,
+	}, nil
+}
+
+// withRefresh calls `call`. In case the access token appears to be expired, it will try to refresh
+// the token, and then try to call `call` again.
+func (c *ClientWR) withRefresh(call func() error) error {
+	err := call()
+	if errStatus, _ := status.FromError(err); errStatus.Code() == codes.Unauthenticated {
+		err := c.Client.LoginUser(c.uid, c.password)
+		if err != nil {
+			return err
+		}
+		return call()
+	}
+	return err
+}
+
+/////////////////////////////////////////////////////////////////////////
+//                               Utility                               //
+/////////////////////////////////////////////////////////////////////////
+
+// Version retrieves the version information of the Encryptonize service.
+func (c *ClientWR) Version() (*VersionResponse, error) {
+	var response *VersionResponse
+	err := c.withRefresh(func() error {
+		var err error
+		response, err = c.Client.Version()
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Health retrieves the current health status of the Encryptonize service.
+func (c *ClientWR) Health() (*HealthResponse, error) {
+	var response *HealthResponse
+	err := c.withRefresh(func() error {
+		var err error
+		response, err = c.Client.Health()
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+/////////////////////////////////////////////////////////////////////////
+//                           User Management                           //
+/////////////////////////////////////////////////////////////////////////
+
+// LoginUser authenticates to the Encryptonize service with the given credentials and sets the
+// resulting access token for future calls. Call `LoginUser` again to switch to a different user.
+func (c *ClientWR) LoginUser(uid, password string) error {
+	err := c.Client.LoginUser(uid, password)
+	if err != nil {
+		return err
+	}
+	c.uid = uid
+	c.password = password
+	return nil
+}
+
+// CreateUser creates a new Encryptonize user with the requested scopes.
+func (c *ClientWR) CreateUser(scopes []Scope) (*CreateUserResponse, error) {
+	var response *CreateUserResponse
+	err := c.withRefresh(func() error {
+		var err error
+		response, err = c.Client.CreateUser(scopes)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// RemoveUser removes a user from the Encryptonize service.
+func (c *ClientWR) RemoveUser(uid string) error {
+	return c.withRefresh(func() error {
+		return c.Client.RemoveUser(uid)
+	})
+}
+
+// CreateGroup creates a new Encryptonize group with the requested scopes.
+func (c *ClientWR) CreateGroup(scopes []Scope) (*CreateGroupResponse, error) {
+	var response *CreateGroupResponse
+	err := c.withRefresh(func() error {
+		var err error
+		response, err = c.Client.CreateGroup(scopes)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// AddUserToGroup adds a user to a group.
+func (c *ClientWR) AddUserToGroup(uid, gid string) error {
+	return c.withRefresh(func() error {
+		return c.Client.AddUserToGroup(uid, gid)
+	})
+}
+
+// RemoveUserFromGroup removes a user from a group.
+func (c *ClientWR) RemoveUserFromGroup(uid, gid string) error {
+	return c.withRefresh(func() error {
+		return c.Client.RemoveUserFromGroup(uid, gid)
+	})
+}
+
+/////////////////////////////////////////////////////////////////////////
+//                              Encryption                             //
+/////////////////////////////////////////////////////////////////////////
+
+// Encrypt encrypts the `plaintext` and tags both `plaintext` and `associatedData` returning the
+// resulting ciphertext.
+func (c *ClientWR) Encrypt(plaintext, associatedData []byte) (*EncryptResponse, error) {
+	var response *EncryptResponse
+	err := c.withRefresh(func() error {
+		var err error
+		response, err = c.Client.Encrypt(plaintext, associatedData)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Decrypt decrypts a previously encrypted `ciphertext` and verifies the integrity of the `ciphertext`
+// and `associatedData`.
+func (c *ClientWR) Decrypt(objectID string, ciphertext, associatedData []byte) (*DecryptResponse, error) {
+	var response *DecryptResponse
+	err := c.withRefresh(func() error {
+		var err error
+		response, err = c.Client.Decrypt(objectID, ciphertext, associatedData)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+/////////////////////////////////////////////////////////////////////////
+//                               Storage                               //
+/////////////////////////////////////////////////////////////////////////
+
+// Store encrypts the `plaintext` and tags both `plaintext` and `associatedData` storing the
+// resulting ciphertext in the Encryptonize service.
+func (c *ClientWR) Store(plaintext, associatedData []byte) (*StoreResponse, error) {
+	var response *StoreResponse
+	err := c.withRefresh(func() error {
+		var err error
+		response, err = c.Client.Store(plaintext, associatedData)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Retrieve decrypts a previously stored object returning the ciphertext.
+func (c *ClientWR) Retrieve(oid string) (*RetrieveResponse, error) {
+	var response *RetrieveResponse
+	err := c.withRefresh(func() error {
+		var err error
+		response, err = c.Client.Retrieve(oid)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// Update replaces the currently stored data of an object with the specified `plaintext` and
+// `associatedData`.
+func (c *ClientWR) Update(oid string, plaintext, associatedData []byte) error {
+	return c.withRefresh(func() error {
+		return c.Client.Update(oid, plaintext, associatedData)
+	})
+}
+
+// Delete removes previously stored data from the Encryptonize service.
+func (c *ClientWR) Delete(oid string) error {
+	return c.withRefresh(func() error {
+		return c.Client.Delete(oid)
+	})
+}
+
+/////////////////////////////////////////////////////////////////////////
+//                             Permissions                             //
+/////////////////////////////////////////////////////////////////////////
+
+// GetPermissions returns a list of IDs that have access to the requested object.
+func (c *ClientWR) GetPermissions(oid string) (*GetPermissionsResponse, error) {
+	var response *GetPermissionsResponse
+	err := c.withRefresh(func() error {
+		var err error
+		response, err = c.Client.GetPermissions(oid)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// AddPermission grants permission for the `target` to the requested object.
+func (c *ClientWR) AddPermission(oid, target string) error {
+	return c.withRefresh(func() error {
+		return c.Client.AddPermission(oid, target)
+	})
+}
+
+// RemovePermission removes permissions for the `target` to the requested object.
+func (c *ClientWR) RemovePermission(oid, target string) error {
+	return c.withRefresh(func() error {
+		return c.Client.RemovePermission(oid, target)
+	})
+}

--- a/client/client_refresh_test.go
+++ b/client/client_refresh_test.go
@@ -1,0 +1,185 @@
+// Copyright 2021 CYBERCRYPT
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"testing"
+
+	"context"
+)
+
+func TestUtilityWR(t *testing.T) {
+	c, err := NewClientWR(context.Background(), endpoint, certPath, uid, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := c.Health(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Version(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUserManagementWR(t *testing.T) {
+	c, err := NewClientWR(context.Background(), endpoint, certPath, uid, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createUserResponse, err := c.CreateUser(scopes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createGroupResponse, err := c.CreateGroup(scopes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.AddUserToGroup(createUserResponse.UserID, createGroupResponse.GroupID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.RemoveUserFromGroup(createUserResponse.UserID, createGroupResponse.GroupID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.RemoveUser(createUserResponse.UserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEncryptWR(t *testing.T) {
+	c, err := NewClientWR(context.Background(), endpoint, certPath, uid, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createUserResponse, err := c.CreateUser(scopes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.LoginUser(createUserResponse.UserID, createUserResponse.Password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plaintext := []byte("foo")
+	associatedData := []byte("bar")
+	encryptResponse, err := c.Encrypt(plaintext, associatedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decryptResponse, err := c.Decrypt(encryptResponse.ObjectID, encryptResponse.Ciphertext, encryptResponse.AssociatedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(decryptResponse.Plaintext) != string(plaintext) {
+		t.Fatal("Decryption returned wrong plaintext")
+	}
+	if string(decryptResponse.AssociatedData) != string(associatedData) {
+		t.Fatal("Decryption returned wrong data")
+	}
+}
+
+func TestStoreWR(t *testing.T) {
+	c, err := NewClientWR(context.Background(), endpoint, certPath, uid, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createUserResponse, err := c.CreateUser(scopes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.LoginUser(createUserResponse.UserID, createUserResponse.Password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plaintext := []byte("foo")
+	associatedData := []byte("bar")
+	storeResponse, err := c.Store(plaintext, associatedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retrieveResponse, err := c.Retrieve(storeResponse.ObjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(retrieveResponse.Plaintext) != string(plaintext) {
+		t.Fatal("Decryption returned wrong plaintext")
+	}
+	if string(retrieveResponse.AssociatedData) != string(associatedData) {
+		t.Fatal("Decryption returned wrong data")
+	}
+
+	plaintext = []byte("foobar")
+	associatedData = []byte("barbaz")
+	err = c.Update(storeResponse.ObjectID, plaintext, associatedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.Delete(storeResponse.ObjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPermissionsWR(t *testing.T) {
+	c, err := NewClientWR(context.Background(), endpoint, certPath, uid, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createUserResponse, err := c.CreateUser(scopes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = c.LoginUser(createUserResponse.UserID, createUserResponse.Password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plaintext := []byte("foo")
+	associatedData := []byte("bar")
+	storeResponse, err := c.Store(plaintext, associatedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.AddPermission(storeResponse.ObjectID, createUserResponse.UserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = c.GetPermissions(storeResponse.ObjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.RemovePermission(storeResponse.ObjectID, createUserResponse.UserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,4 +1,4 @@
-module client
+module github.com/cyber-crypt-com/encryptonize-core/client
 
 go 1.16
 


### PR DESCRIPTION
### Description
This PR adds a version of the Encryptonize client which automatically tries to refresh the access token if it expires. It does so by looking at the error returned by Encryptonize - if the error is "unauthenticated" it will login the user again, and then try to call the endpoint one more time. 

### Relevant Issues/PRs
PR #250 

### Type(s) of Change (Split the PR if you check many)
- [x] Added user feature
- [ ] Added technical feature
- [x] Added tests
- [ ] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Kubernetes changes
- [ ] CI/CD workflow changes

### Testing Checklist
- [x] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make tests`.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [ ] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [x] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
